### PR TITLE
fix: use RELEASE_PLZ_TOKEN to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -48,5 +48,5 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Update release-plz workflow to use `RELEASE_PLZ_TOKEN` instead of `GITHUB_TOKEN`

## Problem
PR #14 (and future release-plz PRs) don't trigger CI workflows because GitHub prevents workflows triggered by `GITHUB_TOKEN` from starting other workflows (to prevent infinite loops).

## Solution
Use a PAT with `repo` and `workflow` scopes so release PRs can trigger standard CI checks (pr.yml, coverage.yml, commit-lint.yml).
