### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "santa"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "santa-data"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Tyler Butler <tyler@tylerbutler.com>"]
 license = "MIT"

--- a/crates/santa-cli/CHANGELOG.md
+++ b/crates/santa-cli/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.2](https://github.com/tylerbutler/santa/compare/santa-v0.1.1...santa-v0.1.2) - 2025-11-17
+
+### Fixed
+
+- make source system extensible without code changes ([#19](https://github.com/tylerbutler/santa/pull/19))
+
 ## [0.1.1](https://github.com/tylerbutler/santa/compare/santa-v0.1.0...santa-v0.1.1) - 2025-11-16
 
 ### Fixed

--- a/crates/santa-cli/Cargo.toml
+++ b/crates/santa-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "santa"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Tyler Butler <tyler@tylerbutler.com>"]
 license = "MIT"
@@ -46,7 +46,7 @@ serde_json = "1.0"
 
 # CCL configuration parser with serde support
 serde_ccl = "0.1.1"
-santa-data = { version = "0.1.1", path = "../santa-data" }
+santa-data = { version = "0.1.2", path = "../santa-data" }
 
 # YAML parser for migration from legacy configs
 serde_yaml = "0.9"

--- a/crates/santa-data/CHANGELOG.md
+++ b/crates/santa-data/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.2](https://github.com/tylerbutler/santa/compare/santa-data-v0.1.1...santa-data-v0.1.2) - 2025-11-17
+
+### Fixed
+
+- make source system extensible without code changes ([#19](https://github.com/tylerbutler/santa/pull/19))
+
 ## [0.1.1](https://github.com/tylerbutler/santa/compare/santa-data-v0.1.0...santa-data-v0.1.1) - 2025-11-17
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `santa-data`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `santa`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `santa-data`

<blockquote>

## [0.1.2](https://github.com/tylerbutler/santa/compare/santa-data-v0.1.1...santa-data-v0.1.2) - 2025-11-17

### Fixed

- make source system extensible without code changes ([#19](https://github.com/tylerbutler/santa/pull/19))
</blockquote>

## `santa`

<blockquote>

## [0.1.2](https://github.com/tylerbutler/santa/compare/santa-v0.1.1...santa-v0.1.2) - 2025-11-17

### Fixed

- make source system extensible without code changes ([#19](https://github.com/tylerbutler/santa/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).