### PR TITLE
fix: disable GitHub release creation in release-plz

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -5,8 +5,8 @@ release_always = false
 # Generate and update CHANGELOG.md
 changelog_update = true
 
-# Create GitHub releases
-git_release_enable = true
+# Create GitHub releases - disabled to let cargo-dist handle release creation with binary assets
+git_release_enable = false
 
 # Publish to crates.io when release PR is merged
 publish = true


### PR DESCRIPTION
## Problem
Release CI fails with: `a release with the same tag name already exists`

Both release-plz and cargo-dist were creating GitHub releases, causing conflicts.

## Root Cause
- **release-plz** with `git_release_enable = true` creates releases
- **cargo-dist** with `dist host --steps=release` also creates releases
- Result: Duplicate creation attempts, releases with 0 assets

## Solution
Disable `git_release_enable` in release-plz to let cargo-dist handle release creation.

**Division of responsibilities:**
- **release-plz**: Version bumps, changelogs, git tags, crates.io publishing
- **cargo-dist**: GitHub releases with binary assets and installers
