### PR TITLE
ci: use per-crate git-cliff configs for changelog generation

### DIFF
--- a/crates/santa-cli/cliff.toml
+++ b/crates/santa-cli/cliff.toml
@@ -1,0 +1,40 @@
+# git-cliff config for santa
+# Auto-generated - edit generate-cliff-configs.py instead
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat\\(santa|santa-cli\\)", group = "Features" },
+    { message = "^fix\\(santa|santa-cli\\)", group = "Bug Fixes" },
+    { message = "^docs\\(santa|santa-cli\\)", group = "Documentation" },
+    { message = "^refactor\\(santa|santa-cli\\)", group = "Refactoring" },
+    { message = "^perf\\(santa|santa-cli\\)", group = "Performance" },
+    { message = "^test\\(santa|santa-cli\\)", group = "Testing" },
+    { message = "^chore\\(santa|santa-cli\\)", group = "Miscellaneous" },
+    { message = "^ci\\(santa|santa-cli\\)", group = "CI" },
+    { message = "^feat:", group = "Features" },
+    { message = "^fix:", group = "Bug Fixes" },
+    { message = "^docs:", group = "Documentation" },
+    { message = "^refactor:", group = "Refactoring" },
+    { message = "^perf:", group = "Performance" },
+    { message = "^test:", group = "Testing" },
+    { message = "^chore:", group = "Miscellaneous" },
+    { message = "^ci:", group = "CI" },
+    { message = ".*", skip = true },
+]

--- a/crates/santa-data/cliff.toml
+++ b/crates/santa-data/cliff.toml
@@ -1,0 +1,40 @@
+# git-cliff config for santa-data
+# Auto-generated - edit generate-cliff-configs.py instead
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat\\(santa-data\\)", group = "Features" },
+    { message = "^fix\\(santa-data\\)", group = "Bug Fixes" },
+    { message = "^docs\\(santa-data\\)", group = "Documentation" },
+    { message = "^refactor\\(santa-data\\)", group = "Refactoring" },
+    { message = "^perf\\(santa-data\\)", group = "Performance" },
+    { message = "^test\\(santa-data\\)", group = "Testing" },
+    { message = "^chore\\(santa-data\\)", group = "Miscellaneous" },
+    { message = "^ci\\(santa-data\\)", group = "CI" },
+    { message = "^feat:", group = "Features" },
+    { message = "^fix:", group = "Bug Fixes" },
+    { message = "^docs:", group = "Documentation" },
+    { message = "^refactor:", group = "Refactoring" },
+    { message = "^perf:", group = "Performance" },
+    { message = "^test:", group = "Testing" },
+    { message = "^chore:", group = "Miscellaneous" },
+    { message = "^ci:", group = "CI" },
+    { message = ".*", skip = true },
+]

--- a/crates/sickle/cliff.toml
+++ b/crates/sickle/cliff.toml
@@ -1,0 +1,40 @@
+# git-cliff config for sickle
+# Auto-generated - edit generate-cliff-configs.py instead
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat\\(sickle\\)", group = "Features" },
+    { message = "^fix\\(sickle\\)", group = "Bug Fixes" },
+    { message = "^docs\\(sickle\\)", group = "Documentation" },
+    { message = "^refactor\\(sickle\\)", group = "Refactoring" },
+    { message = "^perf\\(sickle\\)", group = "Performance" },
+    { message = "^test\\(sickle\\)", group = "Testing" },
+    { message = "^chore\\(sickle\\)", group = "Miscellaneous" },
+    { message = "^ci\\(sickle\\)", group = "CI" },
+    { message = "^feat:", group = "Features" },
+    { message = "^fix:", group = "Bug Fixes" },
+    { message = "^docs:", group = "Documentation" },
+    { message = "^refactor:", group = "Refactoring" },
+    { message = "^perf:", group = "Performance" },
+    { message = "^test:", group = "Testing" },
+    { message = "^chore:", group = "Miscellaneous" },
+    { message = "^ci:", group = "CI" },
+    { message = ".*", skip = true },
+]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -20,53 +20,23 @@ publish = true
 # Check for API breaking changes with cargo-semver-checks
 semver_check = true
 
-# Changelog customization
-[changelog]
-header = """# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-"""
+# Sickle - CCL Parser Library
+[[package]]
+name = "sickle"
+publish = true
+git_tag_enable = false
+changelog_config = "crates/sickle/cliff.toml"
 
 # Santa Data Library - Core data models and CCL parser
 [[package]]
 name = "santa-data"
 publish = true
 git_tag_enable = false
-
-# Exclude commits scoped to other packages from this changelog
-[package.changelog]
-commit_parsers = [
-    { message = "^.*\\(sickle\\)", skip = true },
-    { message = "^.*\\(santa\\)", skip = true },
-    { message = "^.*\\(santa-cli\\)", skip = true },
-]
-
-# Sickle - CCL Parser Library
-[[package]]
-name = "sickle"
-publish = true
-git_tag_enable = false
-
-[package.changelog]
-commit_parsers = [
-    { message = "^.*\\(santa-data\\)", skip = true },
-    { message = "^.*\\(santa\\)", skip = true },
-    { message = "^.*\\(santa-cli\\)", skip = true },
-]
+changelog_config = "crates/santa-data/cliff.toml"
 
 # Santa CLI - Main binary application
-# Note: scopes "santa" and "santa-cli" are treated as equivalent
 [[package]]
 name = "santa"
 publish = true
 git_tag_enable = true
-
-[package.changelog]
-commit_parsers = [
-    { message = "^.*\\(sickle\\)", skip = true },
-    { message = "^.*\\(santa-data\\)", skip = true },
-]
+changelog_config = "crates/santa-cli/cliff.toml"

--- a/scripts/generate-cliff-configs.py
+++ b/scripts/generate-cliff-configs.py
@@ -42,24 +42,31 @@ commit_parsers = [
 '''
 
 
-def generate_config(scope: str) -> str:
+def generate_config(name: str, scopes: list[str]) -> str:
     parsers = ""
+    # Build alternation pattern for multiple scopes: (santa|santa-cli)
+    scope_pattern = "|".join(scopes) if len(scopes) > 1 else scopes[0]
     for type_name, group_name in COMMIT_TYPES:
-        parsers += f'    {{ message = "^{type_name}\\\\({scope}\\\\)", group = "{group_name}" }},\n'
-    return TEMPLATE.format(name=scope, parsers=parsers)
+        # Match scoped commits for this crate
+        parsers += f'    {{ message = "^{type_name}\\\\({scope_pattern}\\\\)", group = "{group_name}" }},\n'
+    for type_name, group_name in COMMIT_TYPES:
+        # Match unscoped commits (apply to all crates)
+        parsers += f'    {{ message = "^{type_name}:", group = "{group_name}" }},\n'
+    return TEMPLATE.format(name=name, parsers=parsers)
 
 
 def main():
+    # (name, path, scopes) - scopes are conventional commit scopes to include
     crates = [
-        ("sickle", "crates/sickle"),
-        ("santa-data", "crates/santa-data"),
-        ("santa", "crates/santa"),
+        ("sickle", "crates/sickle", ["sickle"]),
+        ("santa-data", "crates/santa-data", ["santa-data"]),
+        ("santa", "crates/santa-cli", ["santa", "santa-cli"]),
     ]
 
     root = Path(__file__).parent.parent
 
-    for scope, crate_path in crates:
-        config = generate_config(scope)
+    for name, crate_path, scopes in crates:
+        config = generate_config(name, scopes)
         out_path = root / crate_path / "cliff.toml"
 
         if "--dry-run" in sys.argv:


### PR DESCRIPTION
## Summary

- Fix invalid `[package.changelog]` sections in release-plz.toml that caused CI failures
- Add per-crate `cliff.toml` configs with scope-based commit filtering
- Each crate's changelog includes commits with its scope + unscoped commits

## Changelog behavior

| Commit | sickle | santa-data | santa |
|--------|--------|------------|-------|
| `fix(sickle): ...` | ✅ | ❌ | ❌ |
| `fix(santa-data): ...` | ❌ | ✅ | ❌ |
| `fix(santa): ...` | ❌ | ❌ | ✅ |
| `fix: ...` (unscoped) | ✅ | ✅ | ✅ |

Fixes the Release-plz CI workflow failure on main.