### PR TITLE
fix(ci): resolve release-plz config error and Windows test failure

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,19 +10,11 @@ on:
       - main
 
 jobs:
-  release-plz:
-    name: Release-plz ${{ matrix.command }}
+  release-plz-release:
+    name: Release-plz release
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - command: release
-            concurrency-group: release-plz-release
-          - command: release-pr
-            concurrency-group: release-plz-${{ github.ref }}
-
     concurrency:
-      group: ${{ matrix.concurrency-group }}
+      group: release-plz-release
       cancel-in-progress: false
 
     steps:
@@ -34,10 +26,76 @@ jobs:
 
       - uses: ./.github/actions/setup-rust
 
-      - name: Run release-plz
+      - name: Run release-plz release
         uses: release-plz/action@d529f731ae3e89610ada96eda34e5c6ba3b12214 # ratchet:release-plz/action@v0.5
         with:
-          command: ${{ matrix.command }}
+          command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: ./.github/actions/setup-rust
+
+      - name: Run release-plz release-pr
+        id: release-plz
+        uses: release-plz/action@d529f731ae3e89610ada96eda34e5c6ba3b12214 # ratchet:release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Install git-cliff
+        if: steps.release-plz.outputs.prs_created == 'true'
+        uses: taiki-e/install-action@b4ed516d498dd85ebf2e42c2dbb9556c37faca89 # ratchet:taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Generate changelogs with git-cliff
+        if: steps.release-plz.outputs.prs_created == 'true'
+        run: |
+          # Checkout the PR branch
+          git fetch origin ${{ fromJson(steps.release-plz.outputs.pr).head_branch }}
+          git checkout ${{ fromJson(steps.release-plz.outputs.pr).head_branch }}
+
+          # Generate changelog for each crate using its specific config
+          git cliff --config crates/sickle/cliff.toml \
+            --include-path "crates/sickle/**" \
+            --output crates/sickle/CHANGELOG.md
+
+          git cliff --config crates/santa-data/cliff.toml \
+            --include-path "crates/santa-data/**" \
+            --output crates/santa-data/CHANGELOG.md
+
+          git cliff --config crates/santa-cli/cliff.toml \
+            --include-path "crates/santa-cli/**" \
+            --output crates/santa-cli/CHANGELOG.md
+
+      - name: Commit changelog updates
+        if: steps.release-plz.outputs.prs_created == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Check if there are changes to commit
+          if git diff --quiet crates/*/CHANGELOG.md; then
+            echo "No changelog changes to commit"
+          else
+            git add crates/*/CHANGELOG.md
+            git commit -m "chore: update changelogs with git-cliff"
+            git push origin ${{ fromJson(steps.release-plz.outputs.pr).head_branch }}
+          fi

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,18 +25,18 @@ semver_check = true
 name = "sickle"
 publish = true
 git_tag_enable = false
-changelog_config = "crates/sickle/cliff.toml"
+changelog_update = false  # git-cliff handles this separately
 
 # Santa Data Library - Core data models and CCL parser
 [[package]]
 name = "santa-data"
 publish = true
 git_tag_enable = false
-changelog_config = "crates/santa-data/cliff.toml"
+changelog_update = false  # git-cliff handles this separately
 
 # Santa CLI - Main binary application
 [[package]]
 name = "santa"
 publish = true
 git_tag_enable = true
-changelog_config = "crates/santa-cli/cliff.toml"
+changelog_update = false  # git-cliff handles this separately


### PR DESCRIPTION
## Summary
- Fix `unknown field changelog_config` error by removing invalid field from `[[package]]` sections and using git-cliff directly
- Fix Windows test failure in `test_package_name_injection_scenarios` with platform-aware assertions

## Changes
- **release-plz.toml**: Remove `changelog_config` (only valid at workspace level), add `changelog_update = false` per package
- **release-plz.yml**: Split into separate jobs, add git-cliff step to generate per-crate changelogs with scope filtering
- **sources.rs**: Use `#[cfg(unix)]` / `#[cfg(windows)]` for quote style assertions

## Test plan
- [x] Local tests pass
- [x] CI passes on this PR