### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "santa"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "santa-data"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "derive_builder",
@@ -1912,7 +1912,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sickle"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Tyler Butler <tyler@tylerbutler.com>"]
 license = "MIT"

--- a/crates/santa-cli/CHANGELOG.md
+++ b/crates/santa-cli/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+### Features
+
+- Add --markdown-help flag for documentation generation (#39)
+
+- Display data location and use config directory (#42)
+
+- Reorganize package data by source (#45)
+
+
+### Performance
+
+- Replace ureq and tera with lighter alternatives (#47)
+
+
+### Refactoring
+
+- Remove serde_yaml dependency and migration module (#50)
+
+
+### Testing
+
+- Add tests (#60)
+
+- Add E2E test suite and fix SANTA_CONFIG_PATH handling (#54)
+
+
 ### Bug Fixes
 
 - Add 32-bit architecture support and remove 32-bit Windows CI targets (#34)
@@ -9,33 +35,9 @@ All notable changes to this project will be documented in this file.
 - Resolve source-specific package names in status check (#31)
 
 
-### CI
-
-- Use per-crate git-cliff configs for changelog generation (#35)
-
-- Add semver check
-
-- Further split ci jobs
-
-
-### Miscellaneous
-
-- Release
-
-
-### Miscellaneous
-
-- Release v0.1.4 (#25)
-
-
 ### Features
 
 - Enhance workspace configuration and CI for multi-package best practices (#23)
-
-
-### Miscellaneous
-
-- Release v0.1.3 (#24)
 
 
 ### Bug Fixes
@@ -43,21 +45,9 @@ All notable changes to this project will be documented in this file.
 - Make source system extensible without code changes (#19)
 
 
-### Miscellaneous
-
-- Release v0.1.2 (#20)
-
-
 ### Bug Fixes
 
 - Move templates into santa-cli crate for cargo packaging
-
-
-### Miscellaneous
-
-- Set santa version to 0.1.0
-
-- Release v0.1.1 (#16)
 
 
 ### Bug Fixes
@@ -65,11 +55,6 @@ All notable changes to this project will be documented in this file.
 - Add version requirement for santa-data dependency
 
 - Correct README path in santa-cli Cargo.toml (#9)
-
-
-### Miscellaneous
-
-- Release v0.1.1 (#14)
 
 
 ### Refactoring
@@ -82,11 +67,6 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 - Add Windows package manager to default config sources (#8)
-
-
-### Miscellaneous
-
-- Release (#3)
 
 
 ### Refactoring

--- a/crates/santa-cli/Cargo.toml
+++ b/crates/santa-cli/Cargo.toml
@@ -50,8 +50,8 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde-enum-str = "0.4.0"
 
 # CCL configuration parser with serde support
-sickle = { version = "0.1.0", path = "../sickle", features = ["serde"] }
-santa-data = { version = "0.2.0", path = "../santa-data" }
+sickle = { version = "0.1.1", path = "../sickle", features = ["serde"] }
+santa-data = { version = "0.3.0", path = "../santa-data" }
 
 # Structured logging and tracing
 tracing = "0.1.43"

--- a/crates/santa-data/CHANGELOG.md
+++ b/crates/santa-data/CHANGELOG.md
@@ -2,16 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-### CI
+### Features
 
-- Use per-crate git-cliff configs for changelog generation (#35)
-
-- Add semver check
-
-
-### Miscellaneous
-
-- Release v0.1.4 (#25)
+- Reorganize package data by source (#45)
 
 
 ### Features
@@ -19,34 +12,14 @@ All notable changes to this project will be documented in this file.
 - Enhance workspace configuration and CI for multi-package best practices (#23)
 
 
-### Miscellaneous
-
-- Release v0.1.3 (#24)
-
-
 ### Bug Fixes
 
 - Make source system extensible without code changes (#19)
 
 
-### Miscellaneous
-
-- Release v0.1.2 (#20)
-
-
-### Miscellaneous
-
-- Release v0.1.1 (#14)
-
-
 ### Refactoring
 
 - Remove unused dependencies and fix clippy warnings (#12)
-
-
-### Miscellaneous
-
-- Release (#3)
 
 
 ### Refactoring

--- a/crates/santa-data/Cargo.toml
+++ b/crates/santa-data/Cargo.toml
@@ -21,7 +21,7 @@ dist = false
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
-sickle = { version = "0.1.0", path = "../sickle", features = ["serde"] }
+sickle = { version = "0.1.1", path = "../sickle", features = ["serde"] }
 serde-enum-str = { workspace = true }
 derive_more = { workspace = true }
 

--- a/crates/sickle/CHANGELOG.md
+++ b/crates/sickle/CHANGELOG.md
@@ -2,11 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
-### CI
+### Bug Fixes
 
-- Improve codecov configuration for multi-crate workspace (#33)
+- Parser cleanup and test improvements (#56)
 
-- Use per-crate git-cliff configs for changelog generation (#35)
+- Filter out comments in filter validation tests (#61)
+
+
+### Features
+
+- Add granular feature flags and serde serialization (#44)
+
+
+### Performance
+
+- Optimize release binary size and add size tracking (#48)
+
+
+### Refactoring
+
+- API cleanup and canonical format printer (#43)
+
+
+### Testing
+
+- Exclude known failing tests
 
 
 ### Features

--- a/crates/sickle/Cargo.toml
+++ b/crates/sickle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sickle"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/metrics/binary-size.txt
+++ b/metrics/binary-size.txt
@@ -3,3 +3,4 @@
 # Updated by: just record-size
 
 2025-12-06 v0.2.0 10600184 11MB
+2025-12-16 santa 5644992 5.4MB

--- a/metrics/bloat-sickle.txt
+++ b/metrics/bloat-sickle.txt
@@ -1,15 +1,15 @@
   File  .text    Size  Crate
- 16.7%  96.7% 79.5KiB  *
- 11.4%  66.0% 54.3KiB  sickle
-  1.2%   7.1% 5.82KiB  alloc
-  1.1%   6.3% 5.15KiB  indexmap
-  0.9%   5.4% 4.42KiB  serde_core
-  0.5%   3.0% 2.43KiB  serde
-  0.5%   2.6% 2.16KiB  std
-  0.3%   1.7% 1449  B  core
-  0.3%   1.4% 1220  B  hashbrown
-  0.2%   1.1%  939  B  core
-  0.2%   1.0%  870  B  std
-  0.2%   1.0%  828  B  alloc
+ 16.9%  96.7% 90.3KiB  *
+ 12.2%  70.0% 65.3KiB  sickle
+  1.0%   5.7% 5.35KiB  alloc
+  0.9%   5.2% 4.83KiB  indexmap
+  0.8%   4.8% 4.45KiB  serde_core
+  0.5%   2.6% 2.42KiB  serde
+  0.4%   2.3% 2.15KiB  std
+  0.3%   1.7% 1581  B  core
+  0.3%   1.4% 1380  B  hashbrown
+  0.2%   1.2% 1159  B  alloc
+  0.2%   1.0%  935  B  core
+  0.2%   0.9%  870  B  std
   0.0%   0.0%   35  B  ?
 

--- a/metrics/bloat.txt
+++ b/metrics/bloat.txt
@@ -1,104 +1,76 @@
   File  .text    Size  Crate
- 48.3%  98.5% 5.16MiB  *
-  7.1%  14.4%  772KiB  tera
-  4.5%   9.2%  495KiB  rustls
-  4.4%   9.0%  481KiB  regex_automata
-  3.7%   7.5%  405KiB  clap_builder
-  2.4%   4.8%  259KiB  ?
-  2.3%   4.7%  255KiB  regex_syntax
-  2.3%   4.7%  255KiB  santa
-  2.1%   4.2%  225KiB  moka
-  1.8%   3.7%  197KiB  aho_corasick
-  1.7%   3.5%  190KiB  tokio
-  1.4%   2.9%  158KiB  santa
-  1.2%   2.5%  133KiB  ureq
-  1.1%   2.3%  122KiB  tracing_subscriber
-  1.0%   2.1%  110KiB  alloc
-  0.9%   1.9%  103KiB  ring
-  0.9%   1.8% 98.2KiB  clap_complete
-  0.9%   1.8% 95.8KiB  std
-  0.8%   1.7% 92.1KiB  chrono
-  0.7%   1.4% 73.7KiB  serde_json
-  0.6%   1.2% 66.8KiB  santa_data
-  0.6%   1.2% 65.2KiB  webpki
-  0.4%   0.8% 45.3KiB  url
-  0.4%   0.8% 44.6KiB  sickle
-  0.4%   0.7% 39.7KiB  core
-  0.3%   0.7% 36.1KiB  unsafe_libyaml
-  0.3%   0.6% 32.8KiB  idna
-  0.3%   0.6% 30.0KiB  std
-  0.3%   0.5% 29.1KiB  memchr
-  0.2%   0.4% 23.4KiB  clap_markdown
-  0.2%   0.4% 22.3KiB  alloc
-  0.2%   0.4% 22.0KiB  console
-  0.2%   0.3% 17.8KiB  serde_yaml
-  0.2%   0.3% 17.6KiB  dialoguer
-  0.1%   0.3% 16.0KiB  anyhow
-  0.1%   0.3% 15.7KiB  signal_hook_registry
-  0.1%   0.3% 14.9KiB  icu_normalizer
-  0.1%   0.3% 14.8KiB  tracing_core
-  0.1%   0.3% 13.6KiB  miniz_oxide
-  0.1%   0.2% 12.5KiB  tabular
-  0.1%   0.2% 11.3KiB  flate2
-  0.1%   0.2% 11.2KiB  core
-  0.1%   0.2% 11.0KiB  parking_lot
-  0.1%   0.2% 11.0KiB  crossbeam_channel
-  0.1%   0.2% 10.4KiB  rustls_pki_types
-  0.1%   0.2% 10.1KiB  regex
-  0.1%   0.2% 9.18KiB  chrono_tz
-  0.1%   0.2% 9.02KiB  colored
-  0.1%   0.2% 8.31KiB  rand_chacha
-  0.1%   0.1% 7.56KiB  crossbeam_epoch
-  0.1%   0.1% 7.51KiB  unicode_segmentation
-  0.1%   0.1% 5.61KiB  hashbrown
-  0.0%   0.1% 5.21KiB  serde_core
-  0.0%   0.1% 4.73KiB  which
-  0.0%   0.1% 4.34KiB  pest
-  0.0%   0.1% 3.92KiB  iana_time_zone
-  0.0%   0.1% 3.74KiB  clap_lex
-  0.0%   0.1% 3.50KiB  nu_ansi_term
-  0.0%   0.1% 3.09KiB  parking_lot_core
-  0.0%   0.1% 2.69KiB  sharded_slab
-  0.0%   0.0% 2.67KiB  thread_local
-  0.0%   0.0% 2.66KiB  ryu
-  0.0%   0.0% 2.61KiB  anstyle
-  0.0%   0.0% 2.48KiB  anstream
-  0.0%   0.0% 2.43KiB  smallvec
-  0.0%   0.0% 2.07KiB  once_cell
-  0.0%   0.0% 2.03KiB  base64
-  0.0%   0.0% 2.01KiB  directories
-  0.0%   0.0% 1957  B  tracing_log
-  0.0%   0.0% 1945  B  rand
-  0.0%   0.0% 1941  B  percent_encoding
-  0.0%   0.0% 1825  B  getrandom
-  0.0%   0.0% 1825  B  strsim
-  0.0%   0.0% 1742  B  crc32fast
-  0.0%   0.0% 1609  B  icu_collections
-  0.0%   0.0% 1503  B  mio
-  0.0%   0.0% 1358  B  shell_escape
-  0.0%   0.0% 1272  B  slug
-  0.0%   0.0% 1257  B  humansize
-  0.0%   0.0% 1089  B  matchers
-  0.0%   0.0%  882  B  simd_adler32
+ 67.9%  98.4% 3.94MiB  *
+ 14.3%  20.7%  851KiB  minijinja
+  6.9%  10.0%  412KiB  clap_builder
+  5.2%   7.5%  309KiB  rustls
+  4.4%   6.4%  263KiB  santa
+  4.2%   6.1%  250KiB  ?
+  3.8%   5.5%  227KiB  moka
+  3.3%   4.9%  199KiB  regex_syntax
+  3.2%   4.6%  189KiB  tokio
+  3.0%   4.4%  179KiB  regex_automata
+  2.9%   4.3%  175KiB  santa
+  2.1%   3.0%  123KiB  tracing_subscriber
+  1.6%   2.4% 97.3KiB  clap_complete
+  1.5%   2.2% 91.0KiB  std
+  1.5%   2.2% 89.2KiB  alloc
+  1.3%   1.9% 79.7KiB  santa_data
+  1.1%   1.6% 66.2KiB  ring
+  1.0%   1.5% 62.4KiB  sickle
+  0.8%   1.2% 48.6KiB  minreq
+  0.4%   0.6% 25.2KiB  chrono
+  0.4%   0.6% 24.2KiB  webpki
+  0.4%   0.6% 22.9KiB  clap_markdown
+  0.4%   0.5% 22.2KiB  std
+  0.4%   0.5% 21.4KiB  core
+  0.3%   0.4% 17.4KiB  signal_hook_registry
+  0.3%   0.4% 17.1KiB  alloc
+  0.3%   0.4% 16.7KiB  anyhow
+  0.3%   0.4% 16.1KiB  tracing_core
+  0.2%   0.3% 13.9KiB  console
+  0.2%   0.3% 12.1KiB  tabular
+  0.2%   0.3% 11.3KiB  parking_lot
+  0.2%   0.3% 10.7KiB  core
+  0.2%   0.3% 10.4KiB  crossbeam_channel
+  0.2%   0.2% 9.94KiB  colored
+  0.2%   0.2% 9.26KiB  dialoguer
+  0.1%   0.2% 7.19KiB  crossbeam_epoch
+  0.1%   0.1% 5.93KiB  which
+  0.1%   0.1% 5.09KiB  serde_core
+  0.1%   0.1% 5.09KiB  hashbrown
+  0.1%   0.1% 3.57KiB  clap_lex
+  0.1%   0.1% 3.51KiB  nu_ansi_term
+  0.1%   0.1% 3.42KiB  directories
+  0.0%   0.1% 2.86KiB  parking_lot_core
+  0.0%   0.1% 2.73KiB  sharded_slab
+  0.0%   0.1% 2.63KiB  anstream
+  0.0%   0.1% 2.56KiB  thread_local
+  0.0%   0.1% 2.29KiB  anstyle
+  0.0%   0.0% 1922  B  tracing_log
+  0.0%   0.0% 1868  B  sct
+  0.0%   0.0% 1814  B  strsim
+  0.0%   0.0% 1765  B  mio
+  0.0%   0.0% 1412  B  once_cell
+  0.0%   0.0% 1348  B  shell_escape
+  0.0%   0.0% 1051  B  matchers
   0.0%   0.0%  840  B  unicode_width
+  0.0%   0.0%  825  B  serde
+  0.0%   0.0%  748  B  getrandom
   0.0%   0.0%  743  B  unicode_width
   0.0%   0.0%  738  B  hashbrown
-  0.0%   0.0%  676  B  hashbrown
-  0.0%   0.0%  659  B  dirs_sys
-  0.0%   0.0%  538  B  icu_properties
-  0.0%   0.0%  516  B  serde
-  0.0%   0.0%  423  B  tracing
-  0.0%   0.0%  328  B  log
-  0.0%   0.0%  304  B  utf8_iter
+  0.0%   0.0%  672  B  hashbrown
+  0.0%   0.0%  619  B  dirs_sys
+  0.0%   0.0%  452  B  compiler_builtins
+  0.0%   0.0%  421  B  tracing
+  0.0%   0.0%  376  B  smallvec
   0.0%   0.0%  272  B  futures_core
-  0.0%   0.0%  232  B  terminal_size
+  0.0%   0.0%  244  B  terminal_size
   0.0%   0.0%  191  B  libc
-  0.0%   0.0%  184  B  untrusted
-  0.0%   0.0%  182  B  rand_core
+  0.0%   0.0%  176  B  log
+  0.0%   0.0%  157  B  env_home
   0.0%   0.0%  138  B  futures_util
   0.0%   0.0%  130  B  rustix
   0.0%   0.0%   82  B  tagptr
-  0.0%   0.0%   15  B  home
-  0.0%   0.0%   11  B  subtle
+  0.0%   0.0%   63  B  untrusted
   0.0%   0.0%    8  B  colorchoice
 


### PR DESCRIPTION



## 🤖 New release

* `sickle`: 0.1.0 -> 0.1.1
* `santa-data`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `santa`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `santa-data` breaking changes

```text
--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct ComplexPackageDefinition in /tmp/.tmpK6ZLiG/santa/crates/santa-data/src/schemas.rs:53
  struct ComplexPackageDefinition in /tmp/.tmpK6ZLiG/santa/crates/santa-data/src/schemas.rs:53
```

### ⚠ `santa` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function santa::migration::yaml_to_hocon::convert_yaml_to_hocon, previously in file /tmp/.tmpXKzeb1/santa/src/migration/yaml_to_hocon.rs:13

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_parameter_count_changed.ron

Failed in:
  santa::commands::status_command now takes 7 parameters instead of 4, in /tmp/.tmpK6ZLiG/santa/crates/santa-cli/src/commands.rs:93

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/module_missing.ron

Failed in:
  mod santa::migration, previously in file /tmp/.tmpXKzeb1/santa/src/migration.rs:1
  mod santa::migration::yaml_to_hocon, previously in file /tmp/.tmpXKzeb1/santa/src/migration/yaml_to_hocon.rs:1

--- failure struct_marked_non_exhaustive: struct marked #[non_exhaustive] ---

Description:
A public struct has been marked #[non_exhaustive], which will prevent it from being constructed using a struct literal outside of its crate. It previously had no private fields, so a struct literal could be used to construct it outside its crate.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_marked_non_exhaustive.ron

Failed in:
  struct ComplexPackageDefinition in /tmp/.tmpK6ZLiG/santa/crates/santa-cli/src/data/schemas.rs:45

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct santa::migration::ConfigMigrator, previously in file /tmp/.tmpXKzeb1/santa/src/migration.rs:14

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_added.ron

Failed in:
  trait method santa::configuration::SantaConfigExt::unknown_packages in file /tmp/.tmpK6ZLiG/santa/crates/santa-cli/src/configuration.rs:40

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_missing.ron

Failed in:
  trait santa::traits::Exportable, previously in file /tmp/.tmpXKzeb1/santa/src/traits.rs:283
```

<details><summary><i><b>Changelog</b></i></summary><p>





</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).