### PR TITLE
ci: skip verify-package for release-plz PRs by branch name

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Verify package
         # Skip for release-plz PRs - bumped workspace deps won't exist on crates.io yet
-        if: github.actor != 'github-actions[bot]' || !startsWith(github.head_ref, 'release-plz-')
+        if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
         run: just verify-package
 
       - name: Check for unexpected changes


### PR DESCRIPTION
## Summary
- Simplify the condition for skipping `verify-package` on release-plz PRs
- Check branch name prefix instead of `github.actor` which is unreliable when PRs are re-triggered
