### PR TITLE
fix(ci): use recursive glob for membrowse report artifacts

### DIFF
--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -29,6 +29,6 @@ jobs:
         if: steps.download-reports.outputs.found_artifact == 'true'
         uses: membrowse/membrowse-action/comment-action@v1
         with:
-          json_files: "reports/*.json"
+          json_files: "reports/**/*.json"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Fixes membrowse comment workflow failing to find JSON report files
- The `dawidd6/action-download-artifact` action creates subdirectories for each artifact, so files end up at `reports/<artifact-name>/*.json` rather than `reports/*.json`
- Changed glob from `reports/*.json` to `reports/**/*.json` to match nested files
