### PR TITLE
fix(ci): add checkout step for gh CLI context

### DIFF
--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Download report artifacts
         id: download-reports
         uses: dawidd6/action-download-artifact@v14


### PR DESCRIPTION
## Summary
- The gh CLI needs a git repository context to determine which repo to post comments to
- Adds checkout step before the membrowse comment action
