### PR TITLE
fix(sickle): clean up dead code, no-op logic, and debug output

### DIFF
--- a/crates/sickle/src/lib.rs
+++ b/crates/sickle/src/lib.rs
@@ -536,7 +536,7 @@ fn load_with_options_internal(input: &str, options: &ParserOptions) -> Result<Cc
 pub use de::{from_str, from_str_with_options};
 
 #[cfg(feature = "serde-serialize")]
-pub use ser::to_string;
+pub use ser::{to_string, to_string_with_config};
 
 // Unit tests removed - all functionality is covered by data-driven tests in:
 // - api_core_ccl_parsing.json (basic parsing, multiline values, equals in values)

--- a/crates/sickle/src/model.rs
+++ b/crates/sickle/src/model.rs
@@ -674,13 +674,6 @@ impl CclObject {
         CclObject(map)
     }
 
-    /// Extract the inner IndexMap, consuming the Model
-    /// This is internal-only for crate operations
-    #[allow(dead_code)]
-    pub(crate) fn into_inner(self) -> CclMap {
-        self.0
-    }
-
     /// Insert a string value at the given key
     /// Creates the CCL representation: `{key: {value: {}}}`
     #[cfg(feature = "serde-serialize")]

--- a/crates/sickle/src/parser.rs
+++ b/crates/sickle/src/parser.rs
@@ -332,43 +332,6 @@ fn finalize_value(value: &str, options: &ParserOptions) -> String {
     options.process_tabs(trimmed).into_owned()
 }
 
-/// Remove common leading whitespace from all lines while preserving relative indentation
-///
-/// Note: This function is currently unused as the CCL specification requires preserving
-/// indentation as-is. Kept for potential future use with specific parser behaviors.
-#[allow(dead_code)]
-fn dedent(s: &str) -> String {
-    let lines: Vec<&str> = s.lines().collect();
-    if lines.is_empty() {
-        return String::new();
-    }
-
-    // Find the minimum indentation (ignoring empty lines)
-    let min_indent = lines
-        .iter()
-        .filter(|line| !line.trim().is_empty())
-        .map(|line| line.len() - line.trim_start().len())
-        .min()
-        .unwrap_or(0);
-
-    // Remove that amount of leading whitespace from each line
-    lines
-        .iter()
-        .map(|line| {
-            if line.trim().is_empty() {
-                ""
-            } else if line.len() >= min_indent {
-                &line[min_indent..]
-            } else {
-                line
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-        .trim()
-        .to_string()
-}
-
 /// Build hierarchical structure from flat entries
 pub(crate) fn parse_to_map(
     input: &str,

--- a/crates/sickle/src/ser.rs
+++ b/crates/sickle/src/ser.rs
@@ -260,11 +260,6 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     where
         T: ?Sized + Serialize,
     {
-        // Store the variant name as the key
-        let key = self.current_key.take();
-        if let Some(k) = key {
-            self.current_key = Some(k);
-        }
         self.current_key = Some(variant.to_string());
         value.serialize(self)
     }
@@ -1535,23 +1530,9 @@ mod serde_validation_tests {
         map.insert("key1".to_string(), "value1".to_string());
         map.insert("key2".to_string(), "value2".to_string());
 
-        // Serialize to CCL
         let ccl = to_string(&map).unwrap();
-        println!("Serialized: {}", ccl);
-
-        // Try to deserialize back
-        let result: crate::Result<HashMap<String, String>> = crate::from_str(&ccl);
-
-        match result {
-            Ok(deserialized) => {
-                assert_eq!(map, deserialized);
-                println!("Roundtrip successful!");
-            }
-            Err(e) => {
-                println!("Roundtrip failed: {}", e);
-                panic!("HashMap<String, String> roundtrip failed: {}", e);
-            }
-        }
+        let deserialized: HashMap<String, String> = crate::from_str(&ccl).unwrap();
+        assert_eq!(map, deserialized);
     }
 
     #[test]
@@ -1580,23 +1561,9 @@ mod serde_validation_tests {
             },
         );
 
-        // Serialize to CCL
         let ccl = to_string(&map).unwrap();
-        println!("Serialized: {}", ccl);
-
-        // Try to deserialize back
-        let result: crate::Result<HashMap<String, ConfigValue>> = crate::from_str(&ccl);
-
-        match result {
-            Ok(deserialized) => {
-                assert_eq!(map, deserialized);
-                println!("Roundtrip successful!");
-            }
-            Err(e) => {
-                println!("Roundtrip failed: {}", e);
-                panic!("HashMap<String, Struct> roundtrip failed: {}", e);
-            }
-        }
+        let deserialized: HashMap<String, ConfigValue> = crate::from_str(&ccl).unwrap();
+        assert_eq!(map, deserialized);
     }
 
     #[test]
@@ -1626,23 +1593,9 @@ mod serde_validation_tests {
             ],
         };
 
-        // Serialize to CCL
         let ccl = to_string(&original).unwrap();
-        println!("Serialized: {}", ccl);
-
-        // Try to deserialize back
-        let result: crate::Result<Container> = crate::from_str(&ccl);
-
-        match result {
-            Ok(deserialized) => {
-                assert_eq!(original, deserialized);
-                println!("Roundtrip successful!");
-            }
-            Err(e) => {
-                println!("Roundtrip failed: {}", e);
-                panic!("Vec<Struct> roundtrip failed: {}", e);
-            }
-        }
+        let deserialized: Container = crate::from_str(&ccl).unwrap();
+        assert_eq!(original, deserialized);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove unused `dedent()` function from `parser.rs` and `into_inner()` from `model.rs` (both suppressed with `#[allow(dead_code)]`)
- Remove no-op key take/restore in `serialize_newtype_variant` that immediately overwrote itself
- Remove leftover `println!` debug statements from round-trip tests and simplify match/panic to direct assertions
- Re-export `to_string_with_config` at crate root to match existing `from_str_with_options` symmetry

Related issues filed for deeper design decisions: #92, #93, #94, #95, #96