### PR TITLE
ci: use cached artifact for binary size comparison

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -186,13 +186,35 @@ jobs:
           echo "Analyzing santa-cli dependencies..."
           cargo tree -p santa --depth 3
 
+  # Record binary size on main pushes for PR comparisons
+  binary-size-record:
+    name: Record Binary Size
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: ./.github/actions/setup-rust
+      - name: Build release binary
+        run: cargo build --release
+      - name: Record binary size
+        run: |
+          SIZE=$(stat -c%s target/release/santa)
+          echo "$SIZE" > binary-size.txt
+          echo "Main binary size: $SIZE bytes"
+      - name: Upload binary size artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # ratchet:actions/upload-artifact@v7.0.0
+        with:
+          name: binary-size-main
+          path: binary-size.txt
+          retention-days: 90
+
+  # Compare PR binary size against recorded main size
   binary-size:
     name: Binary Size (Informational)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     steps:
-      - name: Checkout PR
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # ratchet:actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
       - uses: ./.github/actions/setup-rust
 
@@ -210,33 +232,30 @@ jobs:
           echo "bytes=$SIZE" >> "$GITHUB_OUTPUT"
           echo "PR binary size: $SIZE bytes"
 
-      - name: Checkout main branch
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # ratchet:actions/checkout@v5
+      - name: Download main binary size artifact
+        id: download-main-size
+        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3 # ratchet:dawidd6/action-download-artifact@v16
         with:
-          ref: main
-          clean: false
-
-      - name: Build main release binary
-        run: |
-          # Clean previous build to ensure fresh main build
-          cargo clean -p santa
-          cargo build --release
+          workflow: pr.yml
+          branch: main
+          name: binary-size-main
+          path: main-size
+          if_no_artifact_found: warn
 
       - name: Get main binary size
         id: main-size
-        # Use stat directly instead of `just binary-size` because the main
-        # branch may not have the binary-size recipe in its justfile yet.
         run: |
-          SIZE=$(stat -c%s target/release/santa)
-          echo "bytes=$SIZE" >> "$GITHUB_OUTPUT"
-          echo "Main binary size: $SIZE bytes"
-
-      - name: Restore PR checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # ratchet:actions/checkout@v5
-        with:
-          clean: false
+          if [ -f main-size/binary-size.txt ]; then
+            SIZE=$(cat main-size/binary-size.txt)
+            echo "bytes=$SIZE" >> "$GITHUB_OUTPUT"
+            echo "Main binary size: $SIZE bytes"
+          else
+            echo "::warning::No main binary size artifact found, skipping comparison"
+            echo "bytes=0" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Calculate size difference
+        if: steps.main-size.outputs.bytes != '0'
         id: diff
         env:
           PR_SIZE: ${{ steps.pr-size.outputs.bytes }}
@@ -244,12 +263,12 @@ jobs:
         run: just binary-size-compare "$PR_SIZE" "$MAIN_SIZE"
 
       - name: Comment on PR with size change
-        if: steps.diff.outputs.significant == 'true'
+        if: steps.main-size.outputs.bytes != '0' && steps.diff.outputs.significant == 'true'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
         with:
           header: binary-size
           message: |
-            ## 📦 Binary Size Change
+            ## Binary Size Change
 
             | Metric | Value |
             |--------|-------|
@@ -267,7 +286,7 @@ jobs:
             </details>
 
       - name: Remove size comment if not significant
-        if: steps.diff.outputs.significant == 'false'
+        if: steps.main-size.outputs.bytes != '0' && steps.diff.outputs.significant == 'false'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
         with:
           header: binary-size


### PR DESCRIPTION
## Summary

- Add `binary-size-record` job that uploads the release binary size as an artifact on push to main
- Simplify the PR `binary-size` job to download the cached artifact instead of checking out and rebuilding main from source
- Gracefully skip comparison when no artifact exists yet (first run after this change)

This eliminates a redundant `cargo build --release` of main on every PR, saving ~3-5 minutes of CI time per PR run.