### PR TITLE
fix(sickle)!: align boolean parsing with CCL spec

### DIFF
--- a/.changes/unreleased/sickle-fix-bool-spec.yaml
+++ b/.changes/unreleased/sickle-fix-bool-spec.yaml
@@ -1,0 +1,3 @@
+project: sickle
+kind: Breaking
+body: Align boolean parsing with CCL spec — case-insensitive in both modes, lenient accepts `on`/`off`/`1`/`0`

--- a/.changes/unreleased/sickle-remove-get-bool-lenient.yaml
+++ b/.changes/unreleased/sickle-remove-get-bool-lenient.yaml
@@ -1,0 +1,3 @@
+project: sickle
+kind: Breaking
+body: Remove `get_bool_lenient()` in favor of `get_bool_with_options(key, BoolOptions::new().with_lenient())`

--- a/crates/sickle/src/model.rs
+++ b/crates/sickle/src/model.rs
@@ -21,22 +21,30 @@ pub(crate) type CclMapIter<'a> = indexmap::map::Iter<'a, String, Vec<CclObject>>
 /// Options for boolean access operations
 ///
 /// Controls how `get_bool()` interprets string values as booleans.
+/// All comparisons are case-insensitive per the CCL spec.
+///
+/// See <https://ccl.tylerbutler.com/behavior-reference/>
 #[derive(Debug, Clone, Copy, Default)]
 pub struct BoolOptions {
-    /// When true, accepts "yes"/"no" in addition to "true"/"false".
-    /// When false (default), only "true" and "false" are accepted.
+    /// Controls boolean parsing strictness per the CCL spec.
+    ///
+    /// - `false` (default, `boolean_strict`): only accepts `true`/`false`
+    ///   (case-insensitive).
+    /// - `true` (`boolean_lenient`): also accepts `yes`/`no`, `on`/`off`,
+    ///   `1`/`0` (all case-insensitive).
     pub lenient: bool,
 }
 
 impl BoolOptions {
-    /// Create default options (strict mode - only "true"/"false")
+    /// Create default options (`boolean_strict` — only `true`/`false`)
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Create options with lenient mode enabled (accepts "yes"/"no")
-    pub fn lenient() -> Self {
-        Self { lenient: true }
+    /// Enable lenient mode (`boolean_lenient` — accepts `yes`/`no`, `on`/`off`, `1`/`0`)
+    pub fn with_lenient(mut self) -> Self {
+        self.lenient = true;
+        self
     }
 }
 
@@ -442,47 +450,48 @@ impl CclObject {
 
     /// Extract a boolean value from the model with options (no key lookup)
     ///
-    /// Parses the string representation as a boolean.
-    /// - Strict mode (default): only "true" and "false" accepted
-    /// - Lenient mode: also accepts "yes" and "no"
+    /// All comparisons are case-insensitive per the CCL spec.
+    /// - Strict mode (default): only "true" and "false"
+    /// - Lenient mode: also accepts "yes"/"no", "on"/"off", "1"/"0"
     pub(crate) fn as_bool_with_options(&self, options: BoolOptions) -> Result<bool> {
         let s = self.as_string()?;
+        let lower = s.to_lowercase();
         if options.lenient {
-            match s {
-                "true" | "yes" => Ok(true),
-                "false" | "no" => Ok(false),
+            match lower.as_str() {
+                "true" | "yes" | "on" | "1" => Ok(true),
+                "false" | "no" | "off" | "0" => Ok(false),
                 _ => Err(Error::ValueError(format!(
                     "failed to parse '{}' as bool",
                     s
                 ))),
             }
         } else {
-            s.parse::<bool>()
-                .map_err(|_| Error::ValueError(format!("failed to parse '{}' as bool", s)))
+            match lower.as_str() {
+                "true" => Ok(true),
+                "false" => Ok(false),
+                _ => Err(Error::ValueError(format!(
+                    "failed to parse '{}' as bool",
+                    s
+                ))),
+            }
         }
     }
 
-    /// Get a boolean value by key (strict mode)
+    /// Get a boolean value by key (default options, strict mode)
     ///
-    /// Only accepts "true" and "false". For lenient parsing that also
-    /// accepts "yes" and "no", use `get_bool_lenient()`.
+    /// Only accepts "true" and "false" (case-insensitive).
+    /// For lenient parsing, use `get_bool_with_options()`.
     pub fn get_bool(&self, key: &str) -> Result<bool> {
         self.get(key)?.as_bool()
     }
 
     /// Get a boolean value by key with options
     ///
-    /// Allows configuring boolean parsing behavior.
+    /// Behavior depends on `options.lenient` (CCL boolean behavior):
+    /// - `false` (default, `boolean_strict`): only "true"/"false" (case-insensitive)
+    /// - `true` (`boolean_lenient`): also accepts "yes"/"no", "on"/"off", "1"/"0"
     pub fn get_bool_with_options(&self, key: &str, options: BoolOptions) -> Result<bool> {
         self.get(key)?.as_bool_with_options(options)
-    }
-
-    /// Get a boolean value by key (lenient mode)
-    ///
-    /// Accepts "true", "false", "yes", and "no".
-    /// For strict parsing, use `get_bool()`.
-    pub fn get_bool_lenient(&self, key: &str) -> Result<bool> {
-        self.get_bool_with_options(key, BoolOptions::lenient())
     }
 
     /// Extract an integer value from the model (no key lookup)
@@ -748,7 +757,7 @@ mod tests {
 
     #[test]
     fn test_bool_options_lenient() {
-        let opts = BoolOptions::lenient();
+        let opts = BoolOptions::new().with_lenient();
         assert!(opts.lenient);
     }
 

--- a/crates/sickle/tests/data_driven_tests.rs
+++ b/crates/sickle/tests/data_driven_tests.rs
@@ -1162,10 +1162,13 @@ fn test_all_ccl_suites_comprehensive() {
                             (&model, test.args.first().unwrap())
                         };
 
-                        // Use get_bool or get_bool_lenient based on test behaviors
+                        // Use get_bool or get_bool_with_options based on test behaviors
                         let bool_result = if test.behaviors.contains(&"boolean_lenient".to_string())
                         {
-                            parent_model.get_bool_lenient(key)
+                            parent_model.get_bool_with_options(
+                                key,
+                                sickle::BoolOptions::new().with_lenient(),
+                            )
                         } else {
                             parent_model.get_bool(key)
                         };

--- a/crates/sickle/tests/integration_tests.rs
+++ b/crates/sickle/tests/integration_tests.rs
@@ -360,11 +360,12 @@ opt_true = true
 opt_false = false
 "#;
     let model = load(ccl).expect("should load");
+    let lenient = sickle::BoolOptions::new().with_lenient();
     // Lenient mode should accept all variants
-    assert!(model.get_bool_lenient("opt_yes").unwrap());
-    assert!(!model.get_bool_lenient("opt_no").unwrap());
-    assert!(model.get_bool_lenient("opt_true").unwrap());
-    assert!(!model.get_bool_lenient("opt_false").unwrap());
+    assert!(model.get_bool_with_options("opt_yes", lenient).unwrap());
+    assert!(!model.get_bool_with_options("opt_no", lenient).unwrap());
+    assert!(model.get_bool_with_options("opt_true", lenient).unwrap());
+    assert!(!model.get_bool_with_options("opt_false", lenient).unwrap());
 }
 
 #[test]
@@ -381,7 +382,7 @@ flag = yes
     assert!(model.get_bool_with_options("flag", strict_opts).is_err());
 
     // Lenient mode accepts "yes"
-    let lenient_opts = BoolOptions::lenient();
+    let lenient_opts = BoolOptions::new().with_lenient();
     assert!(model.get_bool_with_options("flag", lenient_opts).unwrap());
 }
 
@@ -392,19 +393,21 @@ not_bool = hello
 number = 42
 "#;
     let model = load(ccl).expect("should load");
+    let lenient = sickle::BoolOptions::new().with_lenient();
     // Neither strict nor lenient should accept these
     assert!(model.get_bool("not_bool").is_err());
-    assert!(model.get_bool_lenient("not_bool").is_err());
+    assert!(model.get_bool_with_options("not_bool", lenient).is_err());
     assert!(model.get_bool("number").is_err());
-    assert!(model.get_bool_lenient("number").is_err());
+    assert!(model.get_bool_with_options("number", lenient).is_err());
 }
 
 #[test]
 fn test_get_bool_missing_key() {
     let ccl = "name = value";
     let model = load(ccl).expect("should load");
+    let lenient = sickle::BoolOptions::new().with_lenient();
     assert!(model.get_bool("nonexistent").is_err());
-    assert!(model.get_bool_lenient("nonexistent").is_err());
+    assert!(model.get_bool_with_options("nonexistent", lenient).is_err());
 }
 
 // ============================================================================
@@ -556,21 +559,28 @@ fn test_tabs_in_multiline_values() {
 // ============================================================================
 
 #[test]
-fn test_get_bool_case_sensitivity() {
-    // Boolean parsing is case-sensitive
+fn test_get_bool_case_insensitive() {
+    // Boolean parsing is case-insensitive per CCL spec
     let ccl = r#"
 upper_true = TRUE
 upper_false = FALSE
+mixed_true = True
+mixed_false = fAlSe
 upper_yes = YES
 upper_no = NO
 "#;
     let model = load(ccl).expect("should load");
+    let lenient = sickle::BoolOptions::new().with_lenient();
 
-    // All uppercase variants should fail (case-sensitive)
-    assert!(model.get_bool("upper_true").is_err());
-    assert!(model.get_bool("upper_false").is_err());
-    assert!(model.get_bool_lenient("upper_yes").is_err());
-    assert!(model.get_bool_lenient("upper_no").is_err());
+    // Strict mode: TRUE/FALSE accepted (case-insensitive)
+    assert!(model.get_bool("upper_true").unwrap());
+    assert!(!model.get_bool("upper_false").unwrap());
+    assert!(model.get_bool("mixed_true").unwrap());
+    assert!(!model.get_bool("mixed_false").unwrap());
+
+    // Lenient mode: YES/NO also accepted (case-insensitive)
+    assert!(model.get_bool_with_options("upper_yes", lenient).unwrap());
+    assert!(!model.get_bool_with_options("upper_no", lenient).unwrap());
 }
 
 #[test]
@@ -612,17 +622,21 @@ settings =
     assert!(!settings.get_bool("verbose").unwrap());
 
     // "yes" only works with lenient mode
+    let lenient = sickle::BoolOptions::new().with_lenient();
     assert!(settings.get_bool("experimental").is_err());
-    assert!(settings.get_bool_lenient("experimental").unwrap());
+    assert!(settings
+        .get_bool_with_options("experimental", lenient)
+        .unwrap());
 }
 
 #[test]
 fn test_empty_value_is_not_bool() {
     let ccl = "flag =";
     let model = load(ccl).expect("should load");
+    let lenient = sickle::BoolOptions::new().with_lenient();
     // Empty value cannot be parsed as bool
     assert!(model.get_bool("flag").is_err());
-    assert!(model.get_bool_lenient("flag").is_err());
+    assert!(model.get_bool_with_options("flag", lenient).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Case-insensitive comparisons in both strict and lenient modes (was case-sensitive)
- Lenient mode accepts `on`/`off`/`1`/`0` in addition to `yes`/`no` per [spec](https://ccl.tylerbutler.com/behavior-reference/)
- Remove `get_bool_lenient()` — use `get_bool_with_options(key, BoolOptions::new().with_lenient())` instead
- `BoolOptions::lenient()` replaced with builder: `BoolOptions::new().with_lenient()`