### PR TITLE
ci: pin GitHub Actions to commit hashes via ratchet

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -85,7 +85,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # ratchet:dtolnay/rust-toolchain@stable
 
       - name: Publish crates
         env:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@1fc90f3ed982521116d8ff6d85b948c9b12cae3e # ratchet:anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # ratchet:anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # ratchet:actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version: '22'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
         run: just test-coverage
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # ratchet:codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # ratchet:codecov/codecov-action@v5
         with:
           files: lcov.info
           fail_ci_if_error: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Check semver compatibility
         id: semver
         continue-on-error: true
-        uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # ratchet:obi1kenobi/cargo-semver-checks-action@v2
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # ratchet:obi1kenobi/cargo-semver-checks-action@v2
         with:
           baseline-rev: ${{ steps.merge-base.outputs.sha }}
 
@@ -319,7 +319,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: tylerbutler/actions/changie-check@769fc7847a0abf82ee2f724df9b65426dfb159b5 # ratchet:tylerbutler/actions/changie-check@main
+      - uses: tylerbutler/actions/changie-check@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/changie-check@main
         id: changelog
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Create release pull request
         if: steps.check.outputs.skipped != 'true' && steps.versions.outputs.skipped != 'true'
-        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # ratchet:peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
           title: "Release ${{ steps.versions.outputs.versions }}"


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions references to specific commit hashes using ratchet
- Affects: `auto-tag.yml`, `build.yml`, `claude.yml`, `commit-lint.yml`, `coverage.yml`, `pr.yml`, `release.yml`, `santa-v-release.yml`