### PR TITLE
refactor(sickle): use Pacman-style parser

### DIFF
--- a/.changes/unreleased/sickle-Changed-20260502-174046.yaml
+++ b/.changes/unreleased/sickle-Changed-20260502-174046.yaml
@@ -1,0 +1,4 @@
+project: sickle
+kind: Changed
+body: Align Sickle parsing, printing, and generated CCL test coverage with upstream CCL behavior.
+time: 2026-05-02T17:40:46.577301-07:00

--- a/.changes/unreleased/sickle-Changed-20260502-175032.yaml
+++ b/.changes/unreleased/sickle-Changed-20260502-175032.yaml
@@ -1,0 +1,4 @@
+project: sickle
+kind: Changed
+body: Make Sickle's nom parser dependency unconditional while preserving parser feature gates.
+time: 2026-05-02T17:50:32.562033-07:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,6 +1362,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2298,7 @@ version = "0.2.0"
 dependencies = [
  "colored",
  "indexmap",
+ "nom",
  "serde",
  "serde_derive",
  "serde_json",

--- a/crates/sickle/Cargo.toml
+++ b/crates/sickle/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 
 
 # Core parsing - parse CCL to flat key-value entries
-parse = []
+parse = ["dep:nom"]
 
 # Hierarchy building - build hierarchical CclObject from entries (includes parse)
 hierarchy = ["parse"]
@@ -59,6 +59,9 @@ unstable = []
 [dependencies]
 # Data structures - IndexMap for insertion-order preservation
 indexmap = { version = "2.13.0", features = ["serde"] }
+
+# Parser combinators for the Pacman parser implementation
+nom = { version = "8", optional = true }
 
 # Optional: Serde support for deserialization
 serde = { workspace = true, optional = true }

--- a/crates/sickle/Cargo.toml
+++ b/crates/sickle/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 
 
 # Core parsing - parse CCL to flat key-value entries
-parse = ["dep:nom"]
+parse = []
 
 # Hierarchy building - build hierarchical CclObject from entries (includes parse)
 hierarchy = ["parse"]
@@ -61,7 +61,7 @@ unstable = []
 indexmap = { version = "2.13.0", features = ["serde"] }
 
 # Parser combinators for the Pacman parser implementation
-nom = { version = "8", optional = true }
+nom = "8"
 
 # Optional: Serde support for deserialization
 serde = { workspace = true, optional = true }

--- a/crates/sickle/docs/capabilities.md
+++ b/crates/sickle/docs/capabilities.md
@@ -9,9 +9,9 @@ The test files are the source of truth for all supported features and behaviors.
 
 ## Overview
 
-- **Functions**: 14 distinct functions tested
-- **Behaviors**: 11 distinct behaviors tested
-- **Total test cases**: 379
+- **Functions**: 13 distinct functions tested
+- **Behaviors**: 17 distinct behaviors tested
+- **Total test cases**: 1565
 
 ## Functions
 
@@ -19,44 +19,52 @@ Core Model API methods and operations covered by the test suite:
 
 | Function | Test Cases | Description |
 |----------|------------|-------------|
-| `build_hierarchy` | 83 | Validation type: `build_hierarchy` |
-| `canonical_format` | 11 | Validation type: `canonical_format` |
-| `compose_associative` | 3 | Validation type: `compose_associative` |
-| `filter` | 3 | Validation type: `filter` |
-| `get_bool` | 12 | Validation type: `get_bool` |
-| `get_float` | 6 | Validation type: `get_float` |
-| `get_int` | 11 | Validation type: `get_int` |
-| `get_list` | 43 | Validation type: `get_list` |
-| `get_string` | 11 | Validation type: `get_string` |
-| `identity_left` | 3 | Validation type: `identity_left` |
-| `identity_right` | 3 | Validation type: `identity_right` |
-| `parse` | 166 | Validation type: `parse` |
-| `parse_indented` | 12 | Validation type: `parse_indented` |
-| `round_trip` | 12 | Validation type: `round_trip` |
+| `build_hierarchy` | 195 | Validation type: `build_hierarchy` |
+| `build_model` | 200 | Validation type: `build_model` |
+| `canonical_format` | 16 | Validation type: `canonical_format` |
+| `compose` | 9 | Validation type: `compose_associative` |
+| `filter` | 14 | Validation type: `filter` |
+| `get_bool` | 22 | Validation type: `get_bool` |
+| `get_float` | 10 | Validation type: `get_float` |
+| `get_int` | 16 | Validation type: `get_int` |
+| `get_list` | 44 | Validation type: `get_list` |
+| `get_string` | 82 | Validation type: `get_string` |
+| `parse` | 483 | Validation type: `parse` |
+| `parse_indented` | 405 | Validation type: `build_hierarchy` |
+| `print` | 69 | Validation type: `print` |
 
 ### Function Examples
 
 #### `build_hierarchy`
 
-**Test coverage**: 83 test cases
+**Test coverage**: 195 test cases
 
 **Example usage from tests**:
 
-- **spacing_loose_multiline_various_build_hierarchy** (`api_whitespace_behaviors.json`)
-- **tabs_preserve_in_value_build_hierarchy** (`api_whitespace_behaviors.json`)
+- **s99_fuzz_val_path_0_build_hierarchy** (`api_fuzz_special_chars_seed99.json`)
+- **s99_fuzz_val_item_1_build_hierarchy** (`api_fuzz_special_chars_seed99.json`)
+
+#### `build_model`
+
+**Test coverage**: 200 test cases
+
+**Example usage from tests**:
+
+- **s99_fuzz_val_path_0_build_model** (`api_fuzz_special_chars_seed99.json`)
+- **s99_fuzz_val_item_1_build_model** (`api_fuzz_special_chars_seed99.json`)
 
 #### `canonical_format`
 
-**Test coverage**: 11 test cases
+**Test coverage**: 16 test cases
 
 **Example usage from tests**:
 
-- **spacing_canonical_format_normalizes_loose_canonical_format** (`api_whitespace_behaviors.json`)
-- **tabs_canonical_format_preserve_canonical_format** (`api_whitespace_behaviors.json`)
+- **canonical_format_empty_values_ocaml_reference_canonical_format** (`api_reference_compliant.json`)
+- **canonical_format_unicode_ocaml_reference_canonical_format** (`api_reference_compliant.json`)
 
-#### `compose_associative`
+#### `compose`
 
-**Test coverage**: 3 test cases
+**Test coverage**: 9 test cases
 
 **Example usage from tests**:
 
@@ -65,16 +73,16 @@ Core Model API methods and operations covered by the test suite:
 
 #### `filter`
 
-**Test coverage**: 3 test cases
+**Test coverage**: 14 test cases
 
 **Example usage from tests**:
 
-- **comment_extension_filter** (`api_comments.json`)
-- **comment_syntax_slash_equals_filter** (`api_comments.json`)
+- **filter_by_key_equality_filter** (`api_filter_predicates.json`)
+- **filter_by_value_not_empty_filter** (`api_filter_predicates.json`)
 
 #### `get_bool`
 
-**Test coverage**: 12 test cases
+**Test coverage**: 22 test cases
 
 **Example usage from tests**:
 
@@ -83,7 +91,7 @@ Core Model API methods and operations covered by the test suite:
 
 #### `get_float`
 
-**Test coverage**: 6 test cases
+**Test coverage**: 10 test cases
 
 **Example usage from tests**:
 
@@ -92,7 +100,7 @@ Core Model API methods and operations covered by the test suite:
 
 #### `get_int`
 
-**Test coverage**: 11 test cases
+**Test coverage**: 16 test cases
 
 **Example usage from tests**:
 
@@ -101,66 +109,48 @@ Core Model API methods and operations covered by the test suite:
 
 #### `get_list`
 
-**Test coverage**: 43 test cases
+**Test coverage**: 44 test cases
 
 **Example usage from tests**:
 
-- **basic_list_from_duplicates_get_list** (`api_list_access.json`)
-- **large_list_get_list** (`api_list_access.json`)
+- **single_item_as_list_reference_get_list** (`api_reference_compliant.json`)
+- **mixed_duplicate_single_keys_reference_get_list** (`api_reference_compliant.json`)
 
 #### `get_string`
 
-**Test coverage**: 11 test cases
+**Test coverage**: 82 test cases
 
 **Example usage from tests**:
 
-- **tabs_preserve_in_value_get_string** (`api_whitespace_behaviors.json`)
-- **tabs_preserve_leading_tab_get_string** (`api_whitespace_behaviors.json`)
-
-#### `identity_left`
-
-**Test coverage**: 3 test cases
-
-**Example usage from tests**:
-
-- **monoid_left_identity_basic_identity_left** (`property_algebraic.json`)
-- **monoid_left_identity_nested_identity_left** (`property_algebraic.json`)
-
-#### `identity_right`
-
-**Test coverage**: 3 test cases
-
-**Example usage from tests**:
-
-- **monoid_right_identity_basic_identity_right** (`property_algebraic.json`)
-- **monoid_right_identity_nested_identity_right** (`property_algebraic.json`)
+- **s99_fuzz_val_path_0_get_string** (`api_fuzz_special_chars_seed99.json`)
+- **s99_fuzz_val_item_1_get_string** (`api_fuzz_special_chars_seed99.json`)
 
 #### `parse`
 
-**Test coverage**: 166 test cases
+**Test coverage**: 483 test cases
 
 **Example usage from tests**:
 
-- **spacing_strict_standard_format_parse** (`api_whitespace_behaviors.json`)
-- **spacing_loose_no_spaces_parse** (`api_whitespace_behaviors.json`)
+- **s99_fuzz_single_underscore_parse** (`api_fuzz_special_chars_seed99.json`)
+- **s99_fuzz_single_backslash_parse** (`api_fuzz_special_chars_seed99.json`)
 
 #### `parse_indented`
 
-**Test coverage**: 12 test cases
+**Test coverage**: 405 test cases
 
 **Example usage from tests**:
 
-- **multiline_section_header_value_parse_indented** (`api_proposed_behavior.json`)
-- **unindented_multiline_becomes_continuation_parse_indented** (`api_proposed_behavior.json`)
+- **s99_fuzz_val_path_0_build_hierarchy** (`api_fuzz_special_chars_seed99.json`)
+- **s99_fuzz_val_path_0_build_model** (`api_fuzz_special_chars_seed99.json`)
 
-#### `round_trip`
+#### `print`
 
-**Test coverage**: 12 test cases
+**Test coverage**: 69 test cases
 
 **Example usage from tests**:
 
-- **round_trip_property_basic_round_trip** (`property_algebraic.json`)
-- **round_trip_property_nested_round_trip** (`property_algebraic.json`)
+- **round_trip_basic_print** (`property_round_trip.json`)
+- **round_trip_basic_round_trip** (`property_round_trip.json`)
 
 ## Behaviors
 
@@ -168,23 +158,29 @@ Parser behaviors and configuration options tested by the suite:
 
 | Behavior | Test Cases |
 |----------|------------|
-| `array_order_insertion` | 9 |
+| `array_order_insertion` | 30 |
 | `array_order_lexicographic` | 25 |
-| `boolean_lenient` | 6 |
-| `boolean_strict` | 7 |
-| `crlf_preserve_literal` | 2 |
+| `boolean_lenient` | 10 |
+| `boolean_strict` | 16 |
+| `continuation_tab_to_space` | 4 |
+| `crlf_normalize_to_lf` | 17 |
+| `crlf_preserve_literal` | 17 |
+| `delimiter_first_equals` | 9 |
+| `delimiter_prefer_spaced` | 12 |
+| `indent_spaces` | 13 |
+| `indent_tabs` | 8 |
 | `list_coercion_disabled` | 12 |
-| `list_coercion_enabled` | 18 |
-| `loose_spacing` | 11 |
-| `strict_spacing` | 1 |
-| `tabs_preserve` | 11 |
-| `tabs_to_spaces` | 7 |
+| `list_coercion_enabled` | 17 |
+| `multiline_values` | 23 |
+| `path_traversal` | 30 |
+| `toplevel_indent_preserve` | 2 |
+| `toplevel_indent_strip` | 2 |
 
 ### Behavior Examples
 
 #### `array_order_insertion`
 
-**Test coverage**: 9 test cases
+**Test coverage**: 30 test cases
 
 **Example usage from tests**:
 
@@ -197,12 +193,12 @@ Parser behaviors and configuration options tested by the suite:
 
 **Example usage from tests**:
 
-- **list_with_comments_lexicographic_build_hierarchy** (`api_list_access.json`)
-- **list_with_comments_lexicographic_get_list** (`api_list_access.json`)
+- **mixed_duplicate_single_keys_reference_build_hierarchy** (`api_reference_compliant.json`)
+- **mixed_duplicate_single_keys_reference_get_list** (`api_reference_compliant.json`)
 
 #### `boolean_lenient`
 
-**Test coverage**: 6 test cases
+**Test coverage**: 10 test cases
 
 **Example usage from tests**:
 
@@ -211,21 +207,75 @@ Parser behaviors and configuration options tested by the suite:
 
 #### `boolean_strict`
 
-**Test coverage**: 7 test cases
+**Test coverage**: 16 test cases
 
 **Example usage from tests**:
 
 - **parse_boolean_true_get_bool** (`api_typed_access.json`)
 - **parse_boolean_yes_strict_literal_get_bool** (`api_typed_access.json`)
 
+#### `continuation_tab_to_space`
+
+**Test coverage**: 4 test cases
+
+**Example usage from tests**:
+
+- **tabs_as_whitespace_multiline_parse** (`api_whitespace_behaviors.json`)
+- **tabs_as_whitespace_mixed_indent_parse** (`api_whitespace_behaviors.json`)
+
+#### `crlf_normalize_to_lf`
+
+**Test coverage**: 17 test cases
+
+**Example usage from tests**:
+
+- **crlf_normalize_to_lf_basic_parse** (`api_whitespace_behaviors.json`)
+- **crlf_normalize_to_lf_basic_build_hierarchy** (`api_whitespace_behaviors.json`)
+
 #### `crlf_preserve_literal`
 
-**Test coverage**: 2 test cases
+**Test coverage**: 17 test cases
 
 **Example usage from tests**:
 
 - **canonical_format_line_endings_reference_behavior_parse** (`api_reference_compliant.json`)
 - **canonical_format_line_endings_reference_behavior_canonical_format** (`api_reference_compliant.json`)
+
+#### `delimiter_first_equals`
+
+**Test coverage**: 9 test cases
+
+**Example usage from tests**:
+
+- **delimiter_first_url_with_query_params_parse** (`api_edge_cases.json`)
+- **delimiter_first_url_with_query_params_build_hierarchy** (`api_edge_cases.json`)
+
+#### `delimiter_prefer_spaced`
+
+**Test coverage**: 12 test cases
+
+**Example usage from tests**:
+
+- **url_with_query_params_as_key_parse** (`api_edge_cases.json`)
+- **url_with_query_params_as_key_build_hierarchy** (`api_edge_cases.json`)
+
+#### `indent_spaces`
+
+**Test coverage**: 13 test cases
+
+**Example usage from tests**:
+
+- **canonical_format_unicode_ocaml_reference_canonical_format** (`api_reference_compliant.json`)
+- **canonical_format_line_endings_reference_behavior_canonical_format** (`api_reference_compliant.json`)
+
+#### `indent_tabs`
+
+**Test coverage**: 8 test cases
+
+**Example usage from tests**:
+
+- **print_nested_indent_tabs_print** (`api_whitespace_behaviors.json`)
+- **print_deeply_nested_indent_tabs_print** (`api_whitespace_behaviors.json`)
 
 #### `list_coercion_disabled`
 
@@ -233,52 +283,53 @@ Parser behaviors and configuration options tested by the suite:
 
 **Example usage from tests**:
 
-- **bare_list_error_not_a_list_get_list** (`api_list_access.json`)
 - **single_item_as_list_reference_get_list** (`api_reference_compliant.json`)
+- **mixed_duplicate_single_keys_reference_get_list** (`api_reference_compliant.json`)
 
 #### `list_coercion_enabled`
 
-**Test coverage**: 18 test cases
+**Test coverage**: 17 test cases
 
 **Example usage from tests**:
 
 - **basic_list_from_duplicates_get_list** (`api_list_access.json`)
 - **large_list_get_list** (`api_list_access.json`)
 
-#### `loose_spacing`
+#### `multiline_values`
 
-**Test coverage**: 11 test cases
-
-**Example usage from tests**:
-
-- **spacing_strict_standard_format_parse** (`api_whitespace_behaviors.json`)
-- **spacing_loose_no_spaces_parse** (`api_whitespace_behaviors.json`)
-
-#### `strict_spacing`
-
-**Test coverage**: 1 test cases
+**Test coverage**: 23 test cases
 
 **Example usage from tests**:
 
-- **spacing_strict_standard_format_parse** (`api_whitespace_behaviors.json`)
+- **round_trip_multiline_values_parse** (`property_round_trip.json`)
+- **round_trip_multiline_values_round_trip** (`property_round_trip.json`)
 
-#### `tabs_preserve`
+#### `path_traversal`
 
-**Test coverage**: 11 test cases
-
-**Example usage from tests**:
-
-- **tabs_preserve_in_value_parse** (`api_whitespace_behaviors.json`)
-- **tabs_preserve_in_value_build_hierarchy** (`api_whitespace_behaviors.json`)
-
-#### `tabs_to_spaces`
-
-**Test coverage**: 7 test cases
+**Test coverage**: 30 test cases
 
 **Example usage from tests**:
 
-- **tabs_to_spaces_in_value_parse** (`api_whitespace_behaviors.json`)
-- **tabs_to_spaces_in_value_build_hierarchy** (`api_whitespace_behaviors.json`)
+- **nested_list_access_reference_get_list** (`api_reference_compliant.json`)
+- **complex_mixed_list_scenarios_reference_get_list** (`api_reference_compliant.json`)
+
+#### `toplevel_indent_preserve`
+
+**Test coverage**: 2 test cases
+
+**Example usage from tests**:
+
+- **toplevel_indent_preserve_canonical_canonical_format** (`api_whitespace_behaviors.json`)
+- **toplevel_indent_preserve_round_trip_round_trip** (`api_whitespace_behaviors.json`)
+
+#### `toplevel_indent_strip`
+
+**Test coverage**: 2 test cases
+
+**Example usage from tests**:
+
+- **toplevel_indent_strip_canonical_canonical_format** (`api_whitespace_behaviors.json`)
+- **toplevel_indent_strip_round_trip_round_trip** (`api_whitespace_behaviors.json`)
 
 ## Running Tests
 

--- a/crates/sickle/src/lib.rs
+++ b/crates/sickle/src/lib.rs
@@ -81,6 +81,9 @@ pub mod options;
 pub mod reader;
 
 #[cfg(feature = "parse")]
+mod pacman;
+
+#[cfg(feature = "parse")]
 mod parser;
 
 #[cfg(feature = "printer")]
@@ -403,48 +406,10 @@ fn parse_indented_with_options_internal(
     // If there are multiple entries at min_indent level, parse flat
     // Otherwise, parse as single entry with raw nested content
     if entries_at_min_indent > 1 {
-        parse_flat_entries(&dedented, options)
+        parser::parse_to_entries(&dedented, options)
     } else {
         parse_single_entry_with_raw_value(&dedented, options)
     }
-}
-
-/// Parse all key=value pairs from input as flat entries, ignoring indentation hierarchy
-#[cfg(feature = "parse")]
-fn parse_flat_entries(input: &str, options: &ParserOptions) -> Result<Vec<Entry>> {
-    let mut entries = Vec::new();
-
-    for line in input.lines() {
-        let trimmed = line.trim();
-
-        // Skip empty lines
-        if trimmed.is_empty() {
-            continue;
-        }
-
-        // Extract key=value pairs or treat lines without '=' as keys with empty values
-        if let Some(eq_pos) = trimmed.find('=') {
-            let key = trimmed[..eq_pos].trim().to_string();
-            let value_raw = &trimmed[eq_pos + 1..];
-            // Use options-aware trimming
-            let value = if options.is_strict_spacing() {
-                // Strict: trim only spaces
-                value_raw
-                    .trim_start_matches(' ')
-                    .trim_end_matches(' ')
-                    .to_string()
-            } else {
-                // Loose: trim all whitespace
-                value_raw.trim().to_string()
-            };
-            entries.push(Entry::new(key, value));
-        } else {
-            // Line without '=' is a key with empty value
-            entries.push(Entry::new(trimmed.to_string(), String::new()));
-        }
-    }
-
-    Ok(entries)
 }
 
 /// Parse input as a single entry, preserving the raw value including indentation

--- a/crates/sickle/src/model.rs
+++ b/crates/sickle/src/model.rs
@@ -597,13 +597,10 @@ impl CclObject {
     pub fn get_list_with_options(&self, key: &str, options: ListOptions) -> Result<Vec<String>> {
         if let Some(values) = self.0.get(key) {
             if values.len() > 1 {
-                let items: Result<Vec<String>> = values
+                return values
                     .iter()
                     .map(|value| value.as_string().map(ToString::to_string))
                     .collect();
-                if let Ok(items) = items {
-                    return Ok(items);
-                }
             }
         }
 

--- a/crates/sickle/src/model.rs
+++ b/crates/sickle/src/model.rs
@@ -561,6 +561,9 @@ impl CclObject {
         // With Vec structure: { "": [CclObject({item1}), CclObject({item2}), ...] }
         if non_comment_keys.len() == 1 && non_comment_keys[0].is_empty() {
             if let Ok(children) = self.get_all("") {
+                if children.len() == 1 && children[0].is_empty() {
+                    return None;
+                }
                 let items: Vec<String> = children
                     .iter()
                     .flat_map(|child| child.keys().filter(|k| !k.starts_with('/')).cloned())
@@ -592,6 +595,18 @@ impl CclObject {
     ///
     /// For typed access, use `get_list_typed()`.
     pub fn get_list_with_options(&self, key: &str, options: ListOptions) -> Result<Vec<String>> {
+        if let Some(values) = self.0.get(key) {
+            if values.len() > 1 {
+                let items: Result<Vec<String>> = values
+                    .iter()
+                    .map(|value| value.as_string().map(ToString::to_string))
+                    .collect();
+                if let Ok(items) = items {
+                    return Ok(items);
+                }
+            }
+        }
+
         let model = self.get(key)?;
 
         // Check if this is a bare list (= item syntax)

--- a/crates/sickle/src/pacman.rs
+++ b/crates/sickle/src/pacman.rs
@@ -1,0 +1,45 @@
+//! Pacman parser implementation for CCL.
+
+use nom::bytes::complete::{tag, take_until};
+use nom::character::complete::char;
+use nom::sequence::terminated;
+use nom::IResult;
+use nom::Parser;
+
+pub(crate) fn parse_first_equals_key(input: &str) -> IResult<&str, &str> {
+    terminated(take_until("="), char('=')).parse(input)
+}
+
+pub(crate) fn parse_spaced_delimiter_key(input: &str) -> IResult<&str, &str> {
+    terminated(take_until(" = "), tag(" = ")).parse(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_equals_key_consumes_through_delimiter() {
+        let (remaining, key) = parse_first_equals_key("name=value").unwrap();
+
+        assert_eq!(key, "name");
+        assert_eq!(remaining, "value");
+    }
+
+    #[test]
+    fn first_equals_key_allows_multiline_keys() {
+        let (remaining, key) = parse_first_equals_key("long\nkey = value").unwrap();
+
+        assert_eq!(key, "long\nkey ");
+        assert_eq!(remaining, " value");
+    }
+
+    #[test]
+    fn spaced_delimiter_key_prefers_spaced_equals() {
+        let (remaining, key) =
+            parse_spaced_delimiter_key("https://example.com?q=1 = result").unwrap();
+
+        assert_eq!(key, "https://example.com?q=1");
+        assert_eq!(remaining, "result");
+    }
+}

--- a/crates/sickle/src/parser.rs
+++ b/crates/sickle/src/parser.rs
@@ -65,10 +65,7 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
             continue;
         }
 
-        // Check if this is a multiline key pattern:
-        // Current line has no '=' and a later line provides the delimiter.
         if !trimmed.is_empty() && !trimmed.contains('=') {
-            // Look ahead for the next line with '=' at SAME OR LESS indentation
             let mut j = i + 1;
             let mut found_equals = false;
             while j < lines.len() {
@@ -84,7 +81,6 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
                     break;
                 }
 
-                // Another line at same/less indentation without '=' - could be multiline key continuation
                 j += 1;
             }
 
@@ -97,8 +93,6 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
                     continue;
                 }
 
-                // Join lines from i to j into a single key=value line
-                // Only join lines at the same indentation level
                 let mut key_parts = vec![trimmed];
                 for part_line in lines.iter().take(j).skip(i + 1) {
                     let part_trimmed = part_line.trim();
@@ -117,7 +111,6 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
             }
         }
 
-        // Normal line - pass through
         result.push_str(line);
         result.push('\n');
         prev_had_complete_entry = is_complete_entry;
@@ -156,37 +149,27 @@ fn trim_start_with_cr_option(s: &str, preserve_cr: bool) -> &str {
 ///
 /// Returns the byte position of `=` if found, or None if no valid delimiter exists.
 fn find_delimiter(s: &str, options: &ParserOptions) -> Option<usize> {
+    let first_equals =
+        || crate::pacman::parse_first_equals_key(s).ok().map(|(_, key)| key.len());
+
     if options.is_strict_spacing() {
-        // Strict spacing: require ` = ` pattern (space before and after equals)
-        // OR ` =` at the end of the string (for empty values like "key =")
-        if let Ok((_, key)) = crate::pacman::parse_spaced_delimiter_key(s) {
-            return Some(key.len() + 1);
-        }
-        // Check for ` =` at end of string (space before equals, nothing after)
-        if s.ends_with(" =") {
-            return Some(s.len() - 1);
-        }
-        None
+        find_spaced_delimiter(s)
     } else if options.prefer_spaced_delimiter() {
-        // Prefer-spaced: try ` = ` first, allowing keys to contain bare `=`
-        // This enables keys like URLs with query params: `https://x.com?q=1 = result`
-        if let Ok((_, key)) = crate::pacman::parse_spaced_delimiter_key(s) {
-            return Some(key.len() + 1);
-        }
-        // Check for ` =` at end of string (empty value)
-        if s.ends_with(" =") {
-            return Some(s.len() - 1);
-        }
-        // Fallback: first bare `=` (no spaced delimiter found)
-        crate::pacman::parse_first_equals_key(s)
-            .ok()
-            .map(|(_, key)| key.len())
+        // Try ` = ` first to allow keys with bare `=` (e.g., URLs with query params)
+        find_spaced_delimiter(s).or_else(first_equals)
     } else {
-        // Loose spacing with FirstEquals: any `=` is a valid delimiter
-        crate::pacman::parse_first_equals_key(s)
-            .ok()
-            .map(|(_, key)| key.len())
+        first_equals()
     }
+}
+
+fn find_spaced_delimiter(s: &str) -> Option<usize> {
+    if let Ok((_, key)) = crate::pacman::parse_spaced_delimiter_key(s) {
+        return Some(key.len() + 1);
+    }
+    if s.ends_with(" =") {
+        return Some(s.len() - 1);
+    }
+    None
 }
 
 /// Trim leading whitespace from value on the same line as the key

--- a/crates/sickle/src/parser.rs
+++ b/crates/sickle/src/parser.rs
@@ -54,8 +54,6 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
         }
 
         let base = base_indent.unwrap_or(0);
-
-        // Track if this line is a complete key=value entry
         let is_complete_entry = trimmed.contains('=');
 
         // If this line is indented more than base level, it's a continuation value
@@ -68,25 +66,17 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
         }
 
         // Check if this is a multiline key pattern:
-        // Current line has no '=' AND is at or below base level
-        // AND the previous line was NOT a complete entry (otherwise this is a standalone key)
-        if !trimmed.is_empty() && !trimmed.contains('=') && !prev_had_complete_entry {
+        // Current line has no '=' and a later line provides the delimiter.
+        if !trimmed.is_empty() && !trimmed.contains('=') {
             // Look ahead for the next line with '=' at SAME OR LESS indentation
             let mut j = i + 1;
             let mut found_equals = false;
             while j < lines.len() {
                 let next_line = lines[j];
                 let next_trimmed = next_line.trim();
-                let next_indent = next_line.len() - next_line.trim_start().len();
-
                 if next_trimmed.is_empty() {
                     j += 1;
                     continue;
-                }
-
-                // If indented MORE than current line, this is a continuation value, not a key
-                if next_indent > line_indent {
-                    break;
                 }
 
                 if next_trimmed.contains('=') {
@@ -99,14 +89,21 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
             }
 
             if found_equals && j < lines.len() {
+                if prev_had_complete_entry && !lines[j].trim_start().starts_with('=') {
+                    result.push_str(line);
+                    result.push('\n');
+                    prev_had_complete_entry = is_complete_entry;
+                    i += 1;
+                    continue;
+                }
+
                 // Join lines from i to j into a single key=value line
                 // Only join lines at the same indentation level
                 let mut key_parts = vec![trimmed];
                 for part_line in lines.iter().take(j).skip(i + 1) {
                     let part_trimmed = part_line.trim();
-                    let part_indent = part_line.len() - part_line.trim_start().len();
 
-                    if !part_trimmed.is_empty() && part_indent <= line_indent {
+                    if !part_trimmed.is_empty() {
                         key_parts.push(part_trimmed);
                     }
                 }
@@ -115,7 +112,7 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
                 result.push_str(lines[j].trim());
                 result.push('\n');
                 i = j + 1;
-                prev_had_complete_entry = true; // The joined result is a complete entry
+                prev_had_complete_entry = true;
                 continue;
             }
         }
@@ -128,11 +125,6 @@ fn normalize_multiline_keys(input: &str, preserve_cr: bool) -> String {
     }
 
     result
-}
-
-/// Trim only spaces (not tabs) from the start of a string
-fn trim_spaces_start(s: &str) -> &str {
-    s.trim_start_matches(' ')
 }
 
 /// Trim whitespace from a string, optionally preserving CR
@@ -167,8 +159,8 @@ fn find_delimiter(s: &str, options: &ParserOptions) -> Option<usize> {
     if options.is_strict_spacing() {
         // Strict spacing: require ` = ` pattern (space before and after equals)
         // OR ` =` at the end of the string (for empty values like "key =")
-        if let Some(pos) = s.find(" = ") {
-            return Some(pos + 1);
+        if let Ok((_, key)) = crate::pacman::parse_spaced_delimiter_key(s) {
+            return Some(key.len() + 1);
         }
         // Check for ` =` at end of string (space before equals, nothing after)
         if s.ends_with(" =") {
@@ -178,18 +170,22 @@ fn find_delimiter(s: &str, options: &ParserOptions) -> Option<usize> {
     } else if options.prefer_spaced_delimiter() {
         // Prefer-spaced: try ` = ` first, allowing keys to contain bare `=`
         // This enables keys like URLs with query params: `https://x.com?q=1 = result`
-        if let Some(pos) = s.find(" = ") {
-            return Some(pos + 1);
+        if let Ok((_, key)) = crate::pacman::parse_spaced_delimiter_key(s) {
+            return Some(key.len() + 1);
         }
         // Check for ` =` at end of string (empty value)
         if s.ends_with(" =") {
             return Some(s.len() - 1);
         }
         // Fallback: first bare `=` (no spaced delimiter found)
-        s.find('=')
+        crate::pacman::parse_first_equals_key(s)
+            .ok()
+            .map(|(_, key)| key.len())
     } else {
         // Loose spacing with FirstEquals: any `=` is a valid delimiter
-        s.find('=')
+        crate::pacman::parse_first_equals_key(s)
+            .ok()
+            .map(|(_, key)| key.len())
     }
 }
 
@@ -201,12 +197,12 @@ fn find_delimiter(s: &str, options: &ParserOptions) -> Option<usize> {
 ///
 /// Examples:
 /// - `key = value` → value = `value` (space trimmed)
-/// - `key = \tvalue` with tabs_preserve → value = `\tvalue` (tab is content)
+/// - `key = \tvalue` with tabs_preserve → value = `value` (leading tab is delimiter whitespace)
 /// - `key\t=\tdata` with tabs_to_spaces → value = `data` (tab trimmed)
 fn trim_value(s: &str, options: &ParserOptions) -> String {
     if options.preserve_tabs() {
-        // Only trim spaces, tabs are value content
-        trim_spaces_start(s).to_string()
+        // Leading tabs are delimiter whitespace; interior tabs are value content.
+        s.trim_start_matches([' ', '\t']).to_string()
     } else {
         // Trim all whitespace - tabs are delimiter whitespace (converted later)
         s.trim_start().to_string()

--- a/crates/sickle/src/parser.rs
+++ b/crates/sickle/src/parser.rs
@@ -149,8 +149,11 @@ fn trim_start_with_cr_option(s: &str, preserve_cr: bool) -> &str {
 ///
 /// Returns the byte position of `=` if found, or None if no valid delimiter exists.
 fn find_delimiter(s: &str, options: &ParserOptions) -> Option<usize> {
-    let first_equals =
-        || crate::pacman::parse_first_equals_key(s).ok().map(|(_, key)| key.len());
+    let first_equals = || {
+        crate::pacman::parse_first_equals_key(s)
+            .ok()
+            .map(|(_, key)| key.len())
+    };
 
     if options.is_strict_spacing() {
         find_spaced_delimiter(s)

--- a/crates/sickle/src/printer.rs
+++ b/crates/sickle/src/printer.rs
@@ -43,8 +43,8 @@ use crate::Entry;
 ///
 /// Each entry is formatted as `{key} = {value}`, separated by newlines.
 /// - Empty keys produce ` = {value}` (space before `=`)
-/// - Empty values produce `{key} = ` (trailing space after `=`)
-/// - Multiline values (starting with `\n`) produce `{key} = \n  ...`
+/// - Empty values produce `{key} =` (no trailing space)
+/// - Multiline values (starting with `\n`) produce `{key} =\n  ...`
 ///
 /// ## Round-Trip Property
 ///
@@ -61,7 +61,7 @@ use crate::Entry;
 /// let ccl = "name = Alice\nconfig =\n  port = 8080";
 /// let entries = parse(ccl).unwrap();
 /// let output = print(&entries);
-/// assert_eq!(output, "name = Alice\nconfig = \n  port = 8080");
+/// assert_eq!(output, "name = Alice\nconfig =\n  port = 8080");
 /// ```
 pub fn print(entries: &[Entry]) -> String {
     entries
@@ -69,7 +69,13 @@ pub fn print(entries: &[Entry]) -> String {
         .map(|entry| {
             if entry.key.is_empty() {
                 // Empty keys use bare list syntax: `= value` (no leading space)
-                format!("= {}", entry.value)
+                if entry.value.is_empty() {
+                    "=".to_string()
+                } else {
+                    format!("= {}", entry.value)
+                }
+            } else if entry.value.is_empty() || entry.value.starts_with('\n') {
+                format!("{} ={}", entry.key, entry.value)
             } else {
                 format!("{} = {}", entry.key, entry.value)
             }
@@ -324,7 +330,7 @@ mod tests {
         let input = "key = value\nnested =\n  sub = val";
         let entries = crate::parse(input).unwrap();
         let output = print(&entries);
-        assert_eq!(output, "key = value\nnested = \n  sub = val");
+        assert_eq!(output, "key = value\nnested =\n  sub = val");
     }
 
     #[test]
@@ -342,7 +348,7 @@ mod tests {
         let output = print(&entries);
         assert_eq!(
             output,
-            "config = \n  host = localhost\n  port = 8080\n  db =\n    name = mydb\n    user = admin"
+            "config =\n  host = localhost\n  port = 8080\n  db =\n    name = mydb\n    user = admin"
         );
     }
 
@@ -351,7 +357,7 @@ mod tests {
         let input = "script =\n  #!/bin/bash\n  echo hello\n  exit 0";
         let entries = crate::parse(input).unwrap();
         let output = print(&entries);
-        assert_eq!(output, "script = \n  #!/bin/bash\n  echo hello\n  exit 0");
+        assert_eq!(output, "script =\n  #!/bin/bash\n  echo hello\n  exit 0");
     }
 
     #[test]
@@ -359,7 +365,7 @@ mod tests {
         let input = "empty_section =\n\nother = value";
         let entries = crate::parse(input).unwrap();
         let output = print(&entries);
-        assert_eq!(output, "empty_section = \nother = value");
+        assert_eq!(output, "empty_section =\nother = value");
     }
 
     #[test]
@@ -370,7 +376,7 @@ mod tests {
         let output = print(&entries);
         assert_eq!(
             output,
-            "level1 = \n  level2 =\n    level3 =\n      level4 =\n        deep = value\n        = deep_item"
+            "level1 =\n  level2 =\n    level3 =\n      level4 =\n        deep = value\n        = deep_item"
         );
     }
 
@@ -383,7 +389,7 @@ mod tests {
         let output = print(&entries);
         assert_eq!(
             output,
-            "name = Alice\n= first item\nconfig = \n  port = 3000\n= second item\nfinal = value"
+            "name = Alice\n= first item\nconfig =\n  port = 3000\n= second item\nfinal = value"
         );
     }
 
@@ -394,7 +400,7 @@ mod tests {
         let output = print(&entries);
         assert_eq!(
             output,
-            "app = \n  = item1\n  config =\n    = nested_item\n    db =\n      host = localhost\n      = db_item\n  = item2"
+            "app =\n  = item1\n  config =\n    = nested_item\n    db =\n      host = localhost\n      = db_item\n  = item2"
         );
     }
 
@@ -439,7 +445,7 @@ mod tests {
         // Verify print preserves interleaved order
         assert_eq!(
             printed,
-            "name = Alice\n= first item\nconfig = \n  port = 3000\n= second item\nfinal = value"
+            "name = Alice\n= first item\nconfig =\n  port = 3000\n= second item\nfinal = value"
         );
         // Round-trip now works correctly since `= item` at indent 0
         // re-parses as a new entry (not a continuation of the previous one).

--- a/crates/sickle/tests/common/mod.rs
+++ b/crates/sickle/tests/common/mod.rs
@@ -213,6 +213,9 @@ pub struct TestCase {
     /// Source test name
     #[serde(default)]
     pub source_test: String,
+    /// Predicate used by filter validation tests.
+    #[serde(default)]
+    pub predicate: Option<Predicate>,
 }
 
 impl TestCase {
@@ -251,6 +254,14 @@ pub struct ExpectedOutput {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Entry {
     pub key: String,
+    pub value: String,
+}
+
+/// Predicate for filter validation tests.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Predicate {
+    pub field: String,
+    pub op: String,
     pub value: String,
 }
 

--- a/crates/sickle/tests/data_driven_tests.rs
+++ b/crates/sickle/tests/data_driven_tests.rs
@@ -533,14 +533,36 @@ fn test_filter_function() {
         let test_result = std::panic::catch_unwind(|| {
             // Parse the input with options from test behaviors
             let options = options_from_test(test);
-            let model = load_with_options(test.input(), &options).unwrap_or_else(|e| {
+            let entries = parse_with_options(test.input(), &options).unwrap_or_else(|e| {
                 panic!("Test '{}' failed to parse: {}", test.name, e);
             });
+            let filtered: Vec<_> = if let Some(predicate) = &test.predicate {
+                entries
+                    .iter()
+                    .filter(|entry| {
+                        let field_value = match predicate.field.as_str() {
+                            "key" => entry.key.as_str(),
+                            "value" => entry.value.as_str(),
+                            other => panic!(
+                                "Test '{}': unsupported predicate field '{}'",
+                                test.name, other
+                            ),
+                        };
 
-            // For filter tests, we expect the model to filter out comments
-            // and only contain non-comment entries - use public IndexMap field
-            // Removed direct .0 access
-            let count = model.len();
+                        match predicate.op.as_str() {
+                            "==" => field_value == predicate.value,
+                            "!=" => field_value != predicate.value,
+                            other => {
+                                panic!("Test '{}': unsupported predicate op '{}'", test.name, other)
+                            }
+                        }
+                    })
+                    .collect()
+            } else {
+                entries.iter().filter(|entry| entry.key != "/").collect()
+            };
+
+            let count = filtered.len();
             assert_eq!(
                 count, test.expected.count,
                 "Test '{}' expected {} entries, got {}",
@@ -549,12 +571,16 @@ fn test_filter_function() {
 
             // Verify the actual entries match
             for entry in &test.expected.entries {
-                let value = model.get_string(&entry.key).unwrap_or_else(|e| {
-                    panic!(
-                        "Test '{}': failed to get string for key '{}': {}",
-                        test.name, entry.key, e
-                    )
-                });
+                let value = filtered
+                    .iter()
+                    .find(|actual| actual.key == entry.key)
+                    .map(|actual| actual.value.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Test '{}': failed to find filtered key '{}'",
+                            test.name, entry.key
+                        )
+                    });
 
                 assert_eq!(
                     value, entry.value,
@@ -893,7 +919,7 @@ fn test_all_ccl_suites_comprehensive() {
                     }
                     "filter" => {
                         // "filter" validation tests parse the input, then filter out
-                        // comment entries (where key == "/")
+                        // entries using the generated test predicate.
                         if test.expected.error.is_some() {
                             assert!(entries.is_err(), "Test '{}' expected error", test.name);
                         } else {
@@ -901,9 +927,32 @@ fn test_all_ccl_suites_comprehensive() {
                                 panic!("Test '{}' failed to parse: {}", test.name, e);
                             });
 
-                            // Filter out comment entries (key == "/")
-                            let filtered: Vec<_> =
-                                entry_list.iter().filter(|e| e.key != "/").collect();
+                            let filtered: Vec<_> = if let Some(predicate) = &test.predicate {
+                                entry_list
+                                    .iter()
+                                    .filter(|entry| {
+                                        let field_value = match predicate.field.as_str() {
+                                            "key" => entry.key.as_str(),
+                                            "value" => entry.value.as_str(),
+                                            other => panic!(
+                                                "Test '{}': unsupported predicate field '{}'",
+                                                test.name, other
+                                            ),
+                                        };
+
+                                        match predicate.op.as_str() {
+                                            "==" => field_value == predicate.value,
+                                            "!=" => field_value != predicate.value,
+                                            other => panic!(
+                                                "Test '{}': unsupported predicate op '{}'",
+                                                test.name, other
+                                            ),
+                                        }
+                                    })
+                                    .collect()
+                            } else {
+                                entry_list.iter().filter(|e| e.key != "/").collect()
+                            };
 
                             assert_eq!(
                                 filtered.len(),

--- a/crates/sickle/tests/test_data/api_advanced_processing.json
+++ b/crates/sickle/tests/test_data/api_advanced_processing.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],

--- a/crates/sickle/tests/test_data/api_comments.json
+++ b/crates/sickle/tests/test_data/api_comments.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -79,6 +79,11 @@
         "/= This is an environment section\nport = 8080\nserve = index.html\n/= Database section\nmode = in-memory\nconnections = 16"
       ],
       "name": "comment_extension_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "comment_extension",
       "validation": "filter",
       "variants": []
@@ -123,6 +128,11 @@
         "/= this is a comment"
       ],
       "name": "comment_syntax_slash_equals_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "comment_syntax_slash_equals",
       "validation": "filter",
       "variants": []
@@ -207,6 +217,11 @@
         "== Database Config ==\n/= Connection settings\nhost = localhost\n=== Cache Config ===\n/= Redis configuration\nport = 6379"
       ],
       "name": "section_headers_with_comments_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "section_headers_with_comments",
       "validation": "filter",
       "variants": []

--- a/crates/sickle/tests/test_data/api_core_ccl_hierarchy.json
+++ b/crates/sickle/tests/test_data/api_core_ccl_hierarchy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -39,6 +39,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -47,6 +48,32 @@
       "name": "basic_object_construction_build_hierarchy",
       "source_test": "basic_object_construction",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "age": {
+            "42": {}
+          },
+          "name": {
+            "Alice": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice\nage = 42"
+      ],
+      "name": "basic_object_construction_build_model",
+      "source_test": "basic_object_construction",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -108,6 +135,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -122,7 +150,42 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "server = \n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
+        "object": {
+          "server": {
+            "cache": {
+              "enabled": {
+                "true": {}
+              }
+            },
+            "database": {
+              "host": {
+                "localhost": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
+      ],
+      "name": "deep_nested_objects_build_model",
+      "source_test": "deep_nested_objects",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
       },
       "features": [],
       "functions": [
@@ -181,6 +244,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -189,6 +253,31 @@
       "name": "duplicate_keys_to_lists_build_hierarchy",
       "source_test": "duplicate_keys_to_lists",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "first": {},
+            "second": {},
+            "third": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = first\nitem = second\nitem = third"
+      ],
+      "name": "duplicate_keys_to_lists_build_model",
+      "source_test": "duplicate_keys_to_lists",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -248,6 +337,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -262,7 +352,36 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "config = \n  server = web1\n  server = web2\n  port = 80"
+        "object": {
+          "config": {
+            "port": {
+              "80": {}
+            },
+            "server": {
+              "web1": {},
+              "web2": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  server = web1\n  server = web2\n  port = 80"
+      ],
+      "name": "nested_duplicate_keys_build_model",
+      "source_test": "nested_duplicate_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "config =\n  server = web1\n  server = web2\n  port = 80"
       },
       "features": [],
       "functions": [
@@ -322,6 +441,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -336,7 +456,41 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "name = Alice\nconfig = \n  debug = true\n  timeout = 30\nversion = 1.0"
+        "object": {
+          "config": {
+            "debug": {
+              "true": {}
+            },
+            "timeout": {
+              "30": {}
+            }
+          },
+          "name": {
+            "Alice": {}
+          },
+          "version": {
+            "1.0": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice\nconfig =\n  debug = true\n  timeout = 30\nversion = 1.0"
+      ],
+      "name": "mixed_flat_and_nested_build_model",
+      "source_test": "mixed_flat_and_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "name = Alice\nconfig =\n  debug = true\n  timeout = 30\nversion = 1.0"
       },
       "features": [],
       "functions": [
@@ -395,6 +549,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -409,7 +564,46 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "environments = \n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
+        "object": {
+          "environments": {
+            "dev": {
+              "port": {
+                "3000": {}
+              },
+              "server": {
+                "localhost": {}
+              }
+            },
+            "prod": {
+              "port": {
+                "80": {}
+              },
+              "server": {
+                "web1": {},
+                "web2": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
+      ],
+      "name": "nested_objects_with_lists_build_model",
+      "source_test": "nested_objects_with_lists",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
       },
       "features": [],
       "functions": [
@@ -473,6 +667,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -484,6 +679,37 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "environments": {
+              "production": {
+                "servers": {
+                  "api1": {},
+                  "web1": {},
+                  "web2": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers = web1\n      servers = web2\n      servers = api1"
+      ],
+      "name": "deeply_nested_list_build_model",
+      "source_test": "deeply_nested_list",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "environments",
@@ -492,7 +718,8 @@
       ],
       "behaviors": [
         "list_coercion_disabled",
-        "array_order_lexicographic"
+        "array_order_lexicographic",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [

--- a/crates/sickle/tests/test_data/api_core_ccl_integration.json
+++ b/crates/sickle/tests/test_data/api_core_ccl_integration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -39,6 +39,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -47,6 +48,32 @@
       "name": "complete_basic_workflow_build_hierarchy",
       "source_test": "complete_basic_workflow",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "age": {
+            "42": {}
+          },
+          "name": {
+            "Alice": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice\nage = 42"
+      ],
+      "name": "complete_basic_workflow_build_model",
+      "source_test": "complete_basic_workflow",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -104,6 +131,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -118,7 +146,38 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "database = \n  host = localhost\n  port = 5432\n  enabled = true"
+        "object": {
+          "database": {
+            "enabled": {
+              "true": {}
+            },
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "5432": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  port = 5432\n  enabled = true"
+      ],
+      "name": "complete_nested_workflow_build_model",
+      "source_test": "complete_nested_workflow",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "database =\n  host = localhost\n  port = 5432\n  enabled = true"
       },
       "features": [],
       "functions": [
@@ -181,6 +240,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -195,7 +255,46 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "app = MyApp\nversion = 1.0.0\nconfig = \n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
+        "object": {
+          "app": {
+            "MyApp": {}
+          },
+          "config": {
+            "debug": {
+              "true": {}
+            },
+            "features": {
+              "feature1": {
+                "enabled": {}
+              },
+              "feature2": {
+                "disabled": {}
+              }
+            }
+          },
+          "version": {
+            "1.0.0": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "app = MyApp\nversion = 1.0.0\nconfig =\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
+      ],
+      "name": "complete_mixed_workflow_build_model",
+      "source_test": "complete_mixed_workflow",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "app = MyApp\nversion = 1.0.0\nconfig =\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
       },
       "features": [],
       "functions": [
@@ -265,6 +364,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -279,7 +379,40 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "servers = \n  server = web1\n  server = web2\n  server = web3\nports = \n  port = 80\n  port = 443"
+        "object": {
+          "ports": {
+            "port": {
+              "443": {},
+              "80": {}
+            }
+          },
+          "servers": {
+            "server": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
+      ],
+      "name": "complete_lists_workflow_build_model",
+      "source_test": "complete_lists_workflow",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
       },
       "features": [],
       "functions": [
@@ -349,6 +482,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -363,7 +497,40 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "servers = \n  server = web1\n  server = web2\n  server = web3\nports = \n  port = 80\n  port = 443"
+        "object": {
+          "ports": {
+            "port": {
+              "443": {},
+              "80": {}
+            }
+          },
+          "servers": {
+            "server": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
+      ],
+      "name": "complete_lists_workflow_lexicographic_build_model",
+      "source_test": "complete_lists_workflow_lexicographic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
       },
       "features": [],
       "functions": [
@@ -378,7 +545,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -393,7 +562,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -407,7 +576,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -421,9 +592,10 @@
         }
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -435,13 +607,50 @@
       "variants": []
     },
     {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "settings": {
+              "value1": {
+                "one": {}
+              },
+              "value2": {
+                "two": {}
+              }
+            }
+          },
+          "description": {
+            "Welcome to our app\n  This is a multi-line description\n  With several lines": {}
+          }
+        }
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"
+      ],
+      "name": "complete_multiline_workflow_build_model",
+      "source_test": "complete_multiline_workflow",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig = \n  settings =\n    value1 = one\n    value2 = two"
+        "value": "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"
@@ -531,6 +740,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -545,7 +755,80 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "service = MyMicroservice\nversion = 2.1.0\ndatabase = \n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging = \n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures = \n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
+        "object": {
+          "database": {
+            "credentials": {
+              "password": {
+                "secret123": {}
+              },
+              "user": {
+                "service_user": {}
+              }
+            },
+            "host": {
+              "db.example.com": {}
+            },
+            "pools": {
+              "read": {
+                "5": {}
+              },
+              "write": {
+                "2": {}
+              }
+            },
+            "port": {
+              "5432": {}
+            }
+          },
+          "features": {
+            "feature_a": {
+              "enabled": {}
+            },
+            "feature_b": {
+              "disabled": {}
+            },
+            "feature_c": {
+              "experimental": {}
+            }
+          },
+          "logging": {
+            "level": {
+              "info": {}
+            },
+            "outputs": {
+              "output": {
+                "console": {},
+                "file": {},
+                "syslog": {}
+              }
+            }
+          },
+          "service": {
+            "MyMicroservice": {}
+          },
+          "version": {
+            "2.1.0": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "service = MyMicroservice\nversion = 2.1.0\ndatabase =\n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging =\n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures =\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
+      ],
+      "name": "real_world_complete_workflow_build_model",
+      "source_test": "real_world_complete_workflow",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "service = MyMicroservice\nversion = 2.1.0\ndatabase =\n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging =\n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures =\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
       },
       "features": [],
       "functions": [

--- a/crates/sickle/tests/test_data/api_core_ccl_model.json
+++ b/crates/sickle/tests/test_data/api_core_ccl_model.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
+  "tests": [
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "value"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key = value"
+      ],
+      "name": "model_single_pair_parse",
+      "source_test": "model_single_pair",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "key": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key = value"
+      ],
+      "name": "model_single_pair_build_model",
+      "source_test": "model_single_pair",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "item",
+            "value": "first"
+          },
+          {
+            "key": "item",
+            "value": "second"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "item = first\nitem = second"
+      ],
+      "name": "model_duplicate_keys_merge_to_multi_leaf_parse",
+      "source_test": "model_duplicate_keys_merge_to_multi_leaf",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "first": {},
+            "second": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = first\nitem = second"
+      ],
+      "name": "model_duplicate_keys_merge_to_multi_leaf_build_model",
+      "source_test": "model_duplicate_keys_merge_to_multi_leaf",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "item",
+            "value": "a"
+          },
+          {
+            "key": "item",
+            "value": "b"
+          },
+          {
+            "key": "item",
+            "value": "a"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "item = a\nitem = b\nitem = a"
+      ],
+      "name": "model_repeated_value_is_idempotent_parse",
+      "source_test": "model_repeated_value_is_idempotent",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "a": {},
+            "b": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = a\nitem = b\nitem = a"
+      ],
+      "name": "model_repeated_value_is_idempotent_build_model",
+      "source_test": "model_repeated_value_is_idempotent",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "model_multiple_distinct_keys_parse",
+      "source_test": "model_multiple_distinct_keys",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "model_multiple_distinct_keys_build_model",
+      "source_test": "model_multiple_distinct_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ""
+      ],
+      "name": "model_empty_input_parse",
+      "source_test": "model_empty_input",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {}
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ""
+      ],
+      "name": "model_empty_input_build_model",
+      "source_test": "model_empty_input",
+      "validation": "build_model",
+      "variants": []
+    }
+  ]
+}

--- a/crates/sickle/tests/test_data/api_core_ccl_parsing.json
+++ b/crates/sickle/tests/test_data/api_core_ccl_parsing.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -121,7 +121,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -136,7 +138,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -156,7 +158,7 @@
         "value": "description = First line\n  Second line\n  Third line\ndone = yes"
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"
@@ -202,7 +204,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "empty = \nother = value"
+        "value": "empty =\nother = value"
       },
       "features": [
         "empty_keys"
@@ -245,7 +247,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "database = \n  host = localhost\n  port = 5432"
+        "value": "database =\n  host = localhost\n  port = 5432"
       },
       "features": [],
       "functions": [
@@ -344,14 +346,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "toplevel_indent_strip"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_preserve"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -362,7 +357,8 @@
         ]
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "toplevel_indent_strip"
       ],
       "functions": [
         "parse"
@@ -403,42 +399,6 @@
       ],
       "name": "leading_whitespace_multiple_entries_parse",
       "source_test": "leading_whitespace_multiple_entries",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "toplevel_indent_preserve"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_strip"
-        ]
-      },
-      "expected": {
-        "count": 2,
-        "entries": [
-          {
-            "key": "key",
-            "value": "value"
-          },
-          {
-            "key": "second",
-            "value": "entry"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "  key = value\n  second = entry"
-      ],
-      "name": "leading_whitespace_toplevel_indent_preserve_parse",
-      "source_test": "leading_whitespace_toplevel_indent_preserve",
       "validation": "parse",
       "variants": []
     }

--- a/crates/sickle/tests/test_data/api_edge_cases.json
+++ b/crates/sickle/tests/test_data/api_edge_cases.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -375,46 +375,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key",
-            "value": "\tvalue"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "\tkey\t=\tvalue"
-      ],
-      "name": "key_with_tabs_parse",
-      "source_test": "key_with_tabs",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -467,70 +428,6 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "text",
-            "value": "First\n   four spaces\n\ttab preserved"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse_indented"
-      ],
-      "inputs": [
-        "text = First\n    four spaces\n \ttab preserved"
-      ],
-      "name": "spaces_vs_tabs_continuation_parse_indented",
-      "source_test": "spaces_vs_tabs_continuation",
-      "validation": "parse_indented",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "text",
-            "value": "First\n   four spaces\n\ttab preserved"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse_indented"
-      ],
-      "inputs": [
-        "text = First\n    four spaces\n \ttab preserved"
-      ],
-      "name": "spaces_vs_tabs_continuation_ocaml_reference_parse_indented",
-      "source_test": "spaces_vs_tabs_continuation_ocaml_reference",
-      "validation": "parse_indented",
-      "variants": []
-    },
-    {
       "behaviors": [],
       "expected": {
         "count": 1,
@@ -568,7 +465,7 @@
         ]
       },
       "features": [
-        "empty_keys",
+        "multiline_keys",
         "whitespace"
       ],
       "functions": [
@@ -594,7 +491,7 @@
         ]
       },
       "features": [
-        "empty_keys",
+        "multiline_keys",
         "whitespace"
       ],
       "functions": [
@@ -605,6 +502,164 @@
       ],
       "name": "complex_multi_newline_whitespace_parse",
       "source_test": "complex_multi_newline_whitespace",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "my key",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "my\n key\n= val"
+      ],
+      "name": "multiline_key_with_spaces_parse",
+      "source_test": "multiline_key_with_spaces",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "a b c",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "a\n b\n c\n= val"
+      ],
+      "name": "multiline_key_three_lines_parse",
+      "source_test": "multiline_key_three_lines",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": ""
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "empty_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\n="
+      ],
+      "name": "multiline_key_empty_value_parse",
+      "source_test": "multiline_key_empty_value",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "first",
+            "value": "val1"
+          },
+          {
+            "key": "key",
+            "value": "val2"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "first = val1\nkey\n= val2"
+      ],
+      "name": "multiline_key_with_regular_entry_parse",
+      "source_test": "multiline_key_with_regular_entry",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\n\n= val"
+      ],
+      "name": "multiline_key_blank_lines_between_parse",
+      "source_test": "multiline_key_blank_lines_between",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\n\t= val"
+      ],
+      "name": "multiline_key_tabs_in_continuation_parse",
+      "source_test": "multiline_key_tabs_in_continuation",
       "validation": "parse",
       "variants": []
     },
@@ -730,7 +785,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -741,7 +798,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -755,7 +812,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -766,7 +825,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented"
@@ -912,6 +971,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -920,6 +980,66 @@
       "name": "ocaml_stress_test_original_build_hierarchy",
       "source_test": "ocaml_stress_test_original",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "This is a CCL document": {}
+          },
+          "database": {
+            "enabled": {
+              "true": {}
+            },
+            "limits": {
+              "cpu": {
+                "1500mi": {}
+              },
+              "memory": {
+                "10Gb": {}
+              }
+            },
+            "ports": {
+              "": {
+                "8000": {},
+                "8001": {},
+                "8002": {}
+              }
+            }
+          },
+          "title": {
+            "CCL Example": {}
+          },
+          "user": {
+            "createdAt": {
+              "2024-12-31": {}
+            },
+            "guestId": {
+              "42": {}
+            },
+            "login": {
+              "chshersh": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "comments",
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/= This is a CCL document\ntitle = CCL Example\n\ndatabase =\n  enabled = true\n  ports =\n    = 8000\n    = 8001\n    = 8002\n  limits =\n    cpu = 1500mi\n    memory = 10Gb\n\nuser =\n  guestId = 42\n\nuser =\n  login = chshersh\n  createdAt = 2024-12-31"
+      ],
+      "name": "ocaml_stress_test_original_build_model",
+      "source_test": "ocaml_stress_test_original",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -982,6 +1102,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -993,11 +1114,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mappings": {
+            "config/settings.json": {
+              ".vscode/settings.json": {}
+            },
+            "src/template.env": {
+              ".env": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mappings =\n  config/settings.json = .vscode/settings.json\n  src/template.env = .env"
+      ],
+      "name": "forward_slashes_in_map_keys_build_model",
+      "source_test": "forward_slashes_in_map_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "mappings",
         "config/settings.json"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": ".vscode/settings.json"
@@ -1050,6 +1201,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1058,6 +1210,34 @@
       "name": "backslashes_in_map_keys_build_hierarchy",
       "source_test": "backslashes_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "paths": {
+            "C:\\Users\\config": {
+              "user_settings": {}
+            },
+            "D:\\data\\file.txt": {
+              "backup": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "paths =\n  C:\\Users\\config = user_settings\n  D:\\data\\file.txt = backup"
+      ],
+      "name": "backslashes_in_map_keys_build_model",
+      "source_test": "backslashes_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1096,6 +1276,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1104,6 +1285,34 @@
       "name": "colons_in_map_keys_build_hierarchy",
       "source_test": "colons_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "timestamps": {
+            "12:30:45": {
+              "morning": {}
+            },
+            "23:59:59": {
+              "midnight": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "timestamps =\n  12:30:45 = morning\n  23:59:59 = midnight"
+      ],
+      "name": "colons_in_map_keys_build_model",
+      "source_test": "colons_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1142,6 +1351,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1150,6 +1360,34 @@
       "name": "hyphens_in_map_keys_build_hierarchy",
       "source_test": "hyphens_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "packages": {
+            "another-lib": {
+              "2.3.4": {}
+            },
+            "my-package-name": {
+              "1.0.0": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "packages =\n  my-package-name = 1.0.0\n  another-lib = 2.3.4"
+      ],
+      "name": "hyphens_in_map_keys_build_model",
+      "source_test": "hyphens_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1188,6 +1426,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1196,6 +1435,34 @@
       "name": "at_signs_in_map_keys_build_hierarchy",
       "source_test": "at_signs_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "emails": {
+            "admin@test.org": {
+              "secondary": {}
+            },
+            "user@example.com": {
+              "primary": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "emails =\n  user@example.com = primary\n  admin@test.org = secondary"
+      ],
+      "name": "at_signs_in_map_keys_build_model",
+      "source_test": "at_signs_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1234,6 +1501,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1242,6 +1510,34 @@
       "name": "hash_in_map_keys_build_hierarchy",
       "source_test": "hash_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "issues": {
+            "bug#456": {
+              "closed": {}
+            },
+            "issue#123": {
+              "open": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "issues =\n  issue#123 = open\n  bug#456 = closed"
+      ],
+      "name": "hash_in_map_keys_build_model",
+      "source_test": "hash_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1280,6 +1576,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1288,6 +1585,34 @@
       "name": "brackets_in_map_keys_build_hierarchy",
       "source_test": "brackets_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "arrays": {
+            "items[0]": {
+              "first": {}
+            },
+            "items[1]": {
+              "second": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "arrays =\n  items[0] = first\n  items[1] = second"
+      ],
+      "name": "brackets_in_map_keys_build_model",
+      "source_test": "brackets_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1326,6 +1651,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1334,6 +1660,34 @@
       "name": "parentheses_in_map_keys_build_hierarchy",
       "source_test": "parentheses_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "functions": {
+            "init()": {
+              "setup": {}
+            },
+            "run(args)": {
+              "execute": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "functions =\n  init() = setup\n  run(args) = execute"
+      ],
+      "name": "parentheses_in_map_keys_build_model",
+      "source_test": "parentheses_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1373,6 +1727,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1381,6 +1736,37 @@
       "name": "mixed_special_chars_in_keys_build_hierarchy",
       "source_test": "mixed_special_chars_in_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "complex": {
+            "file#v1.2.3": {
+              "release": {}
+            },
+            "path\\to\\[item]": {
+              "location": {}
+            },
+            "user@host:8080/api": {
+              "endpoint": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "complex =\n  user@host:8080/api = endpoint\n  file#v1.2.3 = release\n  path\\to\\[item] = location"
+      ],
+      "name": "mixed_special_chars_in_keys_build_model",
+      "source_test": "mixed_special_chars_in_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1419,6 +1805,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1427,6 +1814,34 @@
       "name": "url_like_keys_build_hierarchy",
       "source_test": "url_like_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "endpoints": {
+            "http://localhost:3000/test": {
+              "development": {}
+            },
+            "https://api.example.com/v1": {
+              "production": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "endpoints =\n  https://api.example.com/v1 = production\n  http://localhost:3000/test = development"
+      ],
+      "name": "url_like_keys_build_model",
+      "source_test": "url_like_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1462,6 +1877,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1470,6 +1886,29 @@
       "name": "relative_path_parent_parent_build_hierarchy",
       "source_test": "relative_path_parent_parent",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "../..": {
+            "up_two_levels": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "../.. = up_two_levels"
+      ],
+      "name": "relative_path_parent_parent_build_model",
+      "source_test": "relative_path_parent_parent",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1505,6 +1944,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1513,6 +1953,29 @@
       "name": "relative_path_parent_build_hierarchy",
       "source_test": "relative_path_parent",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "../": {
+            "parent_dir": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "../ = parent_dir"
+      ],
+      "name": "relative_path_parent_build_model",
+      "source_test": "relative_path_parent",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1548,6 +2011,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1556,6 +2020,29 @@
       "name": "relative_path_single_dot_build_hierarchy",
       "source_test": "relative_path_single_dot",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ".": {
+            "current_dir": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ". = current_dir"
+      ],
+      "name": "relative_path_single_dot_build_model",
+      "source_test": "relative_path_single_dot",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1591,6 +2078,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1599,6 +2087,29 @@
       "name": "double_slash_build_hierarchy",
       "source_test": "double_slash",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "//": {
+            "double_slash_value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "// = double_slash_value"
+      ],
+      "name": "double_slash_build_model",
+      "source_test": "double_slash",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1634,6 +2145,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1642,6 +2154,29 @@
       "name": "relative_path_in_value_build_hierarchy",
       "source_test": "relative_path_in_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "../../src": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = ../../src"
+      ],
+      "name": "relative_path_in_value_build_model",
+      "source_test": "relative_path_in_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1701,6 +2236,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1712,11 +2248,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mappings": {
+            "../../config": {
+              "../../data": {}
+            },
+            "../foo": {
+              "../bar": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mappings =\n  ../foo = ../bar\n  ../../config = ../../data"
+      ],
+      "name": "relative_path_in_nested_value_build_model",
+      "source_test": "relative_path_in_nested_value",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "mappings",
         "../foo"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": "../bar"
@@ -1769,6 +2335,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1777,6 +2344,34 @@
       "name": "double_slash_in_nested_build_hierarchy",
       "source_test": "double_slash_in_nested",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "urls": {
+            "//api": {
+              "//backup": {}
+            },
+            "//server": {
+              "/root": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "urls =\n  //api = //backup\n  //server = /root"
+      ],
+      "name": "double_slash_in_nested_build_model",
+      "source_test": "double_slash_in_nested",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1817,6 +2412,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1828,12 +2424,44 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "build": {
+              "cache": {
+                "../.cache": {}
+              },
+              "output": {
+                "../../dist": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  build = \n    output = ../../dist\n    cache = ../.cache"
+      ],
+      "name": "relative_paths_deeply_nested_build_model",
+      "source_test": "relative_paths_deeply_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "build",
         "cache"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": "../.cache"
@@ -1888,6 +2516,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1899,12 +2528,44 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "imports": {
+            "..": {
+              "main": {
+                "../src/main": {}
+              },
+              "test": {
+                "../tests": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "imports =\n  .. = \n    main = ../src/main\n    test = ../tests"
+      ],
+      "name": "relative_paths_as_nested_keys_build_model",
+      "source_test": "relative_paths_as_nested_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "imports",
         "..",
         "main"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": "../src/main"
@@ -1962,6 +2623,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1973,12 +2635,49 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "paths": {
+            "absolute": {
+              "root": {
+                "/": {}
+              }
+            },
+            "relative": {
+              "current": {
+                ".": {}
+              },
+              "up": {
+                "../../": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "paths =\n  relative = \n    up = ../../\n    current = .\n  absolute = \n    root = /"
+      ],
+      "name": "mixed_relative_and_absolute_nested_build_model",
+      "source_test": "mixed_relative_and_absolute_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "paths",
         "relative",
         "up"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": "../../"
@@ -2036,6 +2735,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2047,12 +2747,49 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "servers": {
+            "primary": {
+              "api": {
+                "//api.example.com": {}
+              },
+              "cdn": {
+                "//cdn.example.com": {}
+              }
+            },
+            "secondary": {
+              "//internal": {
+                "//backup.example.com": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  primary = \n    api = //api.example.com\n    cdn = //cdn.example.com\n  secondary = \n    //internal = //backup.example.com"
+      ],
+      "name": "double_slash_deeply_nested_build_model",
+      "source_test": "double_slash_deeply_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "servers",
         "primary",
         "api"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": "//api.example.com"
@@ -2102,6 +2839,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2110,6 +2848,29 @@
       "name": "url_as_key_build_hierarchy",
       "source_test": "url_as_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://api.example.com": {
+            "production": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com = production"
+      ],
+      "name": "url_as_key_build_model",
+      "source_test": "url_as_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2166,6 +2927,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2174,6 +2936,29 @@
       "name": "url_with_port_as_key_build_hierarchy",
       "source_test": "url_with_port_as_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "http://localhost:8080": {
+            "dev": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "http://localhost:8080 = dev"
+      ],
+      "name": "url_with_port_as_key_build_model",
+      "source_test": "url_with_port_as_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2209,6 +2994,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2217,6 +3003,29 @@
       "name": "url_with_path_as_key_build_hierarchy",
       "source_test": "url_with_path_as_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://api.example.com/v1/users": {
+            "users_endpoint": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com/v1/users = users_endpoint"
+      ],
+      "name": "url_with_path_as_key_build_model",
+      "source_test": "url_with_path_as_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2252,6 +3061,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2260,6 +3070,29 @@
       "name": "url_in_value_build_hierarchy",
       "source_test": "url_in_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "endpoint": {
+            "https://api.example.com/v1/data": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "endpoint = https://api.example.com/v1/data"
+      ],
+      "name": "url_in_value_build_model",
+      "source_test": "url_in_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2319,6 +3152,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2330,11 +3164,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mappings": {
+            "https://api.example.com": {
+              "https://prod.example.com": {}
+            },
+            "https://staging.example.com": {
+              "https://stage.example.com": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mappings =\n  https://api.example.com = https://prod.example.com\n  https://staging.example.com = https://stage.example.com"
+      ],
+      "name": "urls_as_nested_keys_and_values_build_model",
+      "source_test": "urls_as_nested_keys_and_values",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "mappings",
         "https://api.example.com"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": "https://prod.example.com"
@@ -2394,6 +3258,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2405,13 +3270,52 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "services": {
+              "api": {
+                "backup": {
+                  "https://backup.example.com": {}
+                },
+                "url": {
+                  "https://api.example.com": {}
+                }
+              },
+              "cdn": {
+                "url": {
+                  "https://cdn.example.com": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  services = \n    api = \n      url = https://api.example.com\n      backup = https://backup.example.com\n    cdn = \n      url = https://cdn.example.com"
+      ],
+      "name": "urls_deeply_nested_build_model",
+      "source_test": "urls_deeply_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "services",
         "api",
         "url"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 1,
         "value": "https://api.example.com"
@@ -2475,6 +3379,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2483,6 +3388,36 @@
       "name": "url_with_query_params_as_key_build_hierarchy",
       "source_test": "url_with_query_params_as_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://api.example.com/search?q=test&page=1": {
+            "search_results": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com/search?q=test&page=1 = search_results"
+      ],
+      "name": "url_with_query_params_as_key_build_model",
+      "source_test": "url_with_query_params_as_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2532,6 +3467,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2540,6 +3476,36 @@
       "name": "delimiter_first_url_with_query_params_build_hierarchy",
       "source_test": "delimiter_first_url_with_query_params",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_prefer_spaced"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://api.example.com/search?q": {
+            "test&page=1 = search_results": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com/search?q=test&page=1 = search_results"
+      ],
+      "name": "delimiter_first_url_with_query_params_build_model",
+      "source_test": "delimiter_first_url_with_query_params",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2589,6 +3555,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2597,6 +3564,36 @@
       "name": "delimiter_first_multiple_equals_build_hierarchy",
       "source_test": "delimiter_first_multiple_equals",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_prefer_spaced"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "a": {
+            "b = c=d": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b = c=d"
+      ],
+      "name": "delimiter_first_multiple_equals_build_model",
+      "source_test": "delimiter_first_multiple_equals",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2646,6 +3643,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2654,6 +3652,36 @@
       "name": "delimiter_first_empty_value_build_hierarchy",
       "source_test": "delimiter_first_empty_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_prefer_spaced"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "a": {
+            "b =": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b ="
+      ],
+      "name": "delimiter_first_empty_value_build_model",
+      "source_test": "delimiter_first_empty_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2703,6 +3731,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2711,6 +3740,36 @@
       "name": "delimiter_spaced_multiple_equals_build_hierarchy",
       "source_test": "delimiter_spaced_multiple_equals",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "a=b": {
+            "c=d": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b = c=d"
+      ],
+      "name": "delimiter_spaced_multiple_equals_build_model",
+      "source_test": "delimiter_spaced_multiple_equals",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2760,6 +3819,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2768,6 +3828,36 @@
       "name": "delimiter_spaced_fallback_no_space_build_hierarchy",
       "source_test": "delimiter_spaced_fallback_no_space",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "key": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key=value"
+      ],
+      "name": "delimiter_spaced_fallback_no_space_build_model",
+      "source_test": "delimiter_spaced_fallback_no_space",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2817,6 +3907,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2825,6 +3916,36 @@
       "name": "delimiter_spaced_empty_value_build_hierarchy",
       "source_test": "delimiter_spaced_empty_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "a=b": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b ="
+      ],
+      "name": "delimiter_spaced_empty_value_build_model",
+      "source_test": "delimiter_spaced_empty_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2860,6 +3981,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2868,6 +3990,29 @@
       "name": "url_with_fragment_as_key_build_hierarchy",
       "source_test": "url_with_fragment_as_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://docs.example.com/guide#section-1": {
+            "docs_section_1": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://docs.example.com/guide#section-1 = docs_section_1"
+      ],
+      "name": "url_with_fragment_as_key_build_model",
+      "source_test": "url_with_fragment_as_key",
+      "validation": "build_model",
       "variants": []
     }
   ]

--- a/crates/sickle/tests/test_data/api_errors.json
+++ b/crates/sickle/tests/test_data/api_errors.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -79,7 +79,7 @@
         "count": 0
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -98,7 +98,7 @@
         "count": 0
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -110,6 +110,27 @@
       "source_test": "multiline_plain_nested_error",
       "validation": "parse",
       "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented"
+      ],
+      "inputs": [
+        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
+      ],
+      "name": "mixed_indentation_levels_error_parse_indented",
+      "source_test": "mixed_indentation_levels_error",
+      "validation": "parse_indented",
+      "variants": [
+        "reference_compliant"
+      ]
     }
   ]
 }

--- a/crates/sickle/tests/test_data/api_filter_predicates.json
+++ b/crates/sickle/tests/test_data/api_filter_predicates.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
+  "tests": [
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          },
+          {
+            "key": "mode",
+            "value": "debug"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nmode = debug"
+      ],
+      "name": "filter_by_key_equality_parse",
+      "source_test": "filter_by_key_equality",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nmode = debug"
+      ],
+      "name": "filter_by_key_equality_filter",
+      "predicate": {
+        "field": "key",
+        "op": "==",
+        "value": "port"
+      },
+      "source_test": "filter_by_key_equality",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "name",
+            "value": "app"
+          },
+          {
+            "key": "description",
+            "value": ""
+          },
+          {
+            "key": "version",
+            "value": "1.0"
+          }
+        ]
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "name = app\ndescription =\nversion = 1.0"
+      ],
+      "name": "filter_by_value_not_empty_parse",
+      "source_test": "filter_by_value_not_empty",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "name",
+            "value": "app"
+          },
+          {
+            "key": "version",
+            "value": "1.0"
+          }
+        ]
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "name = app\ndescription =\nversion = 1.0"
+      ],
+      "name": "filter_by_value_not_empty_filter",
+      "predicate": {
+        "field": "value",
+        "op": "!=",
+        "value": ""
+      },
+      "source_test": "filter_by_value_not_empty",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "debug",
+            "value": "true"
+          },
+          {
+            "key": "verbose",
+            "value": "false"
+          },
+          {
+            "key": "logging",
+            "value": "true"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "debug = true\nverbose = false\nlogging = true"
+      ],
+      "name": "filter_by_value_equality_parse",
+      "source_test": "filter_by_value_equality",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "debug",
+            "value": "true"
+          },
+          {
+            "key": "logging",
+            "value": "true"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "debug = true\nverbose = false\nlogging = true"
+      ],
+      "name": "filter_by_value_equality_filter",
+      "predicate": {
+        "field": "value",
+        "op": "==",
+        "value": "true"
+      },
+      "source_test": "filter_by_value_equality",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "filter_no_matches_parse",
+      "source_test": "filter_no_matches",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "filter_no_matches_filter",
+      "predicate": {
+        "field": "key",
+        "op": "==",
+        "value": "nonexistent"
+      },
+      "source_test": "filter_no_matches",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "filter_keeps_all_parse",
+      "source_test": "filter_keeps_all",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "filter_keeps_all_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "nonexistent"
+      },
+      "source_test": "filter_keeps_all",
+      "validation": "filter",
+      "variants": []
+    }
+  ]
+}

--- a/crates/sickle/tests/test_data/api_fuzz_special_chars_seed1.json
+++ b/crates/sickle/tests/test_data/api_fuzz_special_chars_seed1.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -851,6 +852,31 @@
       "name": "s1_fuzz_val_name_0_build_hierarchy",
       "source_test": "s1_fuzz_val_name_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data?x77]x88": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data?x77]x88"
+      ],
+      "name": "s1_fuzz_val_name_0_build_model",
+      "source_test": "s1_fuzz_val_name_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -913,6 +939,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -921,6 +948,31 @@
       "name": "s1_fuzz_val_data_1_build_hierarchy",
       "source_test": "s1_fuzz_val_data_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "data": {
+            "data'x23!x22": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "data = data'x23!x22"
+      ],
+      "name": "s1_fuzz_val_data_1_build_model",
+      "source_test": "s1_fuzz_val_data_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -983,6 +1035,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -991,6 +1044,31 @@
       "name": "s1_fuzz_val_mode_2_build_hierarchy",
       "source_test": "s1_fuzz_val_mode_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mode": {
+            "data?x30\"x15~x73": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mode = data?x30\"x15~x73"
+      ],
+      "name": "s1_fuzz_val_mode_2_build_model",
+      "source_test": "s1_fuzz_val_mode_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1053,6 +1131,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1061,6 +1140,31 @@
       "name": "s1_fuzz_val_name_3_build_hierarchy",
       "source_test": "s1_fuzz_val_name_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data$x23~x81@x41": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data$x23~x81@x41"
+      ],
+      "name": "s1_fuzz_val_name_3_build_model",
+      "source_test": "s1_fuzz_val_name_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1123,6 +1227,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1131,6 +1236,31 @@
       "name": "s1_fuzz_val_user_4_build_hierarchy",
       "source_test": "s1_fuzz_val_user_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "user": {
+            "data}x85$x2$x43": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "user = data}x85$x2$x43"
+      ],
+      "name": "s1_fuzz_val_user_4_build_model",
+      "source_test": "s1_fuzz_val_user_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1198,6 +1328,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1206,6 +1337,34 @@
       "name": "s1_fuzz_nested_ampersand_rbrace_0_build_hierarchy",
       "source_test": "s1_fuzz_nested_ampersand_rbrace_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "&alpha": {
+            "nested297": {}
+          },
+          "}gamma": {
+            "deep715": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "&alpha = nested297\n}gamma = deep715"
+      ],
+      "name": "s1_fuzz_nested_ampersand_rbrace_0_build_model",
+      "source_test": "s1_fuzz_nested_ampersand_rbrace_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1273,6 +1432,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1281,6 +1441,34 @@
       "name": "s1_fuzz_nested_question_rbracket_1_build_hierarchy",
       "source_test": "s1_fuzz_nested_question_rbracket_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "?port": {
+            "nested105": {}
+          },
+          "]name": {
+            "deep997": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "?port = nested105\n]name = deep997"
+      ],
+      "name": "s1_fuzz_nested_question_rbracket_1_build_model",
+      "source_test": "s1_fuzz_nested_question_rbracket_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1348,6 +1536,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1356,6 +1545,34 @@
       "name": "s1_fuzz_nested_plus_slash_2_build_hierarchy",
       "source_test": "s1_fuzz_nested_plus_slash_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "+config": {
+            "nested427": {}
+          },
+          "/server": {
+            "deep329": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "+config = nested427\n/server = deep329"
+      ],
+      "name": "s1_fuzz_nested_plus_slash_2_build_model",
+      "source_test": "s1_fuzz_nested_plus_slash_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1423,6 +1640,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1431,6 +1649,34 @@
       "name": "s1_fuzz_nested_ampersand_dollar_3_build_hierarchy",
       "source_test": "s1_fuzz_nested_ampersand_dollar_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$port": {
+            "deep486": {}
+          },
+          "&name": {
+            "nested41": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "&name = nested41\n$port = deep486"
+      ],
+      "name": "s1_fuzz_nested_ampersand_dollar_3_build_model",
+      "source_test": "s1_fuzz_nested_ampersand_dollar_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1498,6 +1744,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1506,6 +1753,34 @@
       "name": "s1_fuzz_nested_tilde_squote_4_build_hierarchy",
       "source_test": "s1_fuzz_nested_tilde_squote_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "'beta": {
+            "deep158": {}
+          },
+          "~beta": {
+            "nested332": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "~beta = nested332\n'beta = deep158"
+      ],
+      "name": "s1_fuzz_nested_tilde_squote_4_build_model",
+      "source_test": "s1_fuzz_nested_tilde_squote_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1573,6 +1848,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1581,6 +1857,34 @@
       "name": "s1_fuzz_nested_hyphen_ampersand_5_build_hierarchy",
       "source_test": "s1_fuzz_nested_hyphen_ampersand_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "&epsilon": {
+            "deep891": {}
+          },
+          "-config": {
+            "nested723": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "-config = nested723\n&epsilon = deep891"
+      ],
+      "name": "s1_fuzz_nested_hyphen_ampersand_5_build_model",
+      "source_test": "s1_fuzz_nested_hyphen_ampersand_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1648,6 +1952,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1656,6 +1961,34 @@
       "name": "s1_fuzz_nested_dollar_asterisk_6_build_hierarchy",
       "source_test": "s1_fuzz_nested_dollar_asterisk_6",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$path": {
+            "nested884": {}
+          },
+          "*mode": {
+            "deep88": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "$path = nested884\n*mode = deep88"
+      ],
+      "name": "s1_fuzz_nested_dollar_asterisk_6_build_model",
+      "source_test": "s1_fuzz_nested_dollar_asterisk_6",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1723,6 +2056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1731,6 +2065,34 @@
       "name": "s1_fuzz_nested_underscore_semicolon_7_build_hierarchy",
       "source_test": "s1_fuzz_nested_underscore_semicolon_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ";alpha": {
+            "deep519": {}
+          },
+          "_path": {
+            "nested515": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "_path = nested515\n;alpha = deep519"
+      ],
+      "name": "s1_fuzz_nested_underscore_semicolon_7_build_model",
+      "source_test": "s1_fuzz_nested_underscore_semicolon_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1798,6 +2160,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1806,6 +2169,34 @@
       "name": "s1_fuzz_nested_at_rparen_8_build_hierarchy",
       "source_test": "s1_fuzz_nested_at_rparen_8",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")gamma": {
+            "deep475": {}
+          },
+          "@server": {
+            "nested286": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "@server = nested286\n)gamma = deep475"
+      ],
+      "name": "s1_fuzz_nested_at_rparen_8_build_model",
+      "source_test": "s1_fuzz_nested_at_rparen_8",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1873,6 +2264,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1881,6 +2273,34 @@
       "name": "s1_fuzz_nested_rbrace_tilde_9_build_hierarchy",
       "source_test": "s1_fuzz_nested_rbrace_tilde_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "}beta": {
+            "nested295": {}
+          },
+          "~alpha": {
+            "deep415": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "}beta = nested295\n~alpha = deep415"
+      ],
+      "name": "s1_fuzz_nested_rbrace_tilde_9_build_model",
+      "source_test": "s1_fuzz_nested_rbrace_tilde_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/crates/sickle/tests/test_data/api_fuzz_special_chars_seed42.json
+++ b/crates/sickle/tests/test_data/api_fuzz_special_chars_seed42.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -851,6 +852,31 @@
       "name": "s42_fuzz_val_data_0_build_hierarchy",
       "source_test": "s42_fuzz_val_data_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "data": {
+            "data|x58": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "data = data|x58"
+      ],
+      "name": "s42_fuzz_val_data_0_build_model",
+      "source_test": "s42_fuzz_val_data_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -913,6 +939,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -921,6 +948,31 @@
       "name": "s42_fuzz_val_beta_1_build_hierarchy",
       "source_test": "s42_fuzz_val_beta_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "beta": {
+            "data\\x12": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "beta = data\\x12"
+      ],
+      "name": "s42_fuzz_val_beta_1_build_model",
+      "source_test": "s42_fuzz_val_beta_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -983,6 +1035,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -991,6 +1044,31 @@
       "name": "s42_fuzz_val_name_2_build_hierarchy",
       "source_test": "s42_fuzz_val_name_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data\\x77\"x95_x85": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data\\x77\"x95_x85"
+      ],
+      "name": "s42_fuzz_val_name_2_build_model",
+      "source_test": "s42_fuzz_val_name_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1053,6 +1131,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1061,6 +1140,31 @@
       "name": "s42_fuzz_val_path_3_build_hierarchy",
       "source_test": "s42_fuzz_val_path_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "data-x45": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = data-x45"
+      ],
+      "name": "s42_fuzz_val_path_3_build_model",
+      "source_test": "s42_fuzz_val_path_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1123,6 +1227,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1131,6 +1236,31 @@
       "name": "s42_fuzz_val_name_4_build_hierarchy",
       "source_test": "s42_fuzz_val_name_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data{x49\"x55": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data{x49\"x55"
+      ],
+      "name": "s42_fuzz_val_name_4_build_model",
+      "source_test": "s42_fuzz_val_name_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1198,6 +1328,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1206,6 +1337,34 @@
       "name": "s42_fuzz_nested_lbrace_rbracket_0_build_hierarchy",
       "source_test": "s42_fuzz_nested_lbrace_rbracket_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "]name": {
+            "deep985": {}
+          },
+          "{host": {
+            "nested259": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{host = nested259\n]name = deep985"
+      ],
+      "name": "s42_fuzz_nested_lbrace_rbracket_0_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_rbracket_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1273,6 +1432,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1281,6 +1441,34 @@
       "name": "s42_fuzz_nested_lbrace_rbrace_1_build_hierarchy",
       "source_test": "s42_fuzz_nested_lbrace_rbrace_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "{port": {
+            "nested169": {}
+          },
+          "}mode": {
+            "deep270": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{port = nested169\n}mode = deep270"
+      ],
+      "name": "s42_fuzz_nested_lbrace_rbrace_1_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_rbrace_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1348,6 +1536,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1356,6 +1545,34 @@
       "name": "s42_fuzz_nested_ampersand_percent_2_build_hierarchy",
       "source_test": "s42_fuzz_nested_ampersand_percent_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "%data": {
+            "deep952": {}
+          },
+          "&delta": {
+            "nested56": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "&delta = nested56\n%data = deep952"
+      ],
+      "name": "s42_fuzz_nested_ampersand_percent_2_build_model",
+      "source_test": "s42_fuzz_nested_ampersand_percent_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1423,6 +1640,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1431,6 +1649,34 @@
       "name": "s42_fuzz_nested_dquote_gt_3_build_hierarchy",
       "source_test": "s42_fuzz_nested_dquote_gt_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"epsilon": {
+            "nested885": {}
+          },
+          ">user": {
+            "deep168": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"epsilon = nested885\n>user = deep168"
+      ],
+      "name": "s42_fuzz_nested_dquote_gt_3_build_model",
+      "source_test": "s42_fuzz_nested_dquote_gt_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1498,6 +1744,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1506,6 +1753,34 @@
       "name": "s42_fuzz_nested_percent_dollar_4_build_hierarchy",
       "source_test": "s42_fuzz_nested_percent_dollar_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$path": {
+            "deep65": {}
+          },
+          "%alpha": {
+            "nested438": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "%alpha = nested438\n$path = deep65"
+      ],
+      "name": "s42_fuzz_nested_percent_dollar_4_build_model",
+      "source_test": "s42_fuzz_nested_percent_dollar_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1573,6 +1848,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1581,6 +1857,34 @@
       "name": "s42_fuzz_nested_dquote_rbracket_5_build_hierarchy",
       "source_test": "s42_fuzz_nested_dquote_rbracket_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"gamma": {
+            "nested524": {}
+          },
+          "]mode": {
+            "deep57": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"gamma = nested524\n]mode = deep57"
+      ],
+      "name": "s42_fuzz_nested_dquote_rbracket_5_build_model",
+      "source_test": "s42_fuzz_nested_dquote_rbracket_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1648,6 +1952,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1656,6 +1961,34 @@
       "name": "s42_fuzz_nested_lbrace_ampersand_6_build_hierarchy",
       "source_test": "s42_fuzz_nested_lbrace_ampersand_6",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "&port": {
+            "deep22": {}
+          },
+          "{data": {
+            "nested474": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{data = nested474\n&port = deep22"
+      ],
+      "name": "s42_fuzz_nested_lbrace_ampersand_6_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_ampersand_6",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1723,6 +2056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1731,6 +2065,34 @@
       "name": "s42_fuzz_nested_semicolon_hyphen_7_build_hierarchy",
       "source_test": "s42_fuzz_nested_semicolon_hyphen_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "-server": {
+            "deep284": {}
+          },
+          ";data": {
+            "nested239": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ";data = nested239\n-server = deep284"
+      ],
+      "name": "s42_fuzz_nested_semicolon_hyphen_7_build_model",
+      "source_test": "s42_fuzz_nested_semicolon_hyphen_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1798,6 +2160,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1806,6 +2169,34 @@
       "name": "s42_fuzz_nested_lbrace_rbrace_8_build_hierarchy",
       "source_test": "s42_fuzz_nested_lbrace_rbrace_8",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "{host": {
+            "nested125": {}
+          },
+          "}user": {
+            "deep615": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{host = nested125\n}user = deep615"
+      ],
+      "name": "s42_fuzz_nested_lbrace_rbrace_8_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_rbrace_8",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1873,6 +2264,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1881,6 +2273,34 @@
       "name": "s42_fuzz_nested_tilde_ampersand_9_build_hierarchy",
       "source_test": "s42_fuzz_nested_tilde_ampersand_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "&gamma": {
+            "deep966": {}
+          },
+          "~beta": {
+            "nested835": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "~beta = nested835\n&gamma = deep966"
+      ],
+      "name": "s42_fuzz_nested_tilde_ampersand_9_build_model",
+      "source_test": "s42_fuzz_nested_tilde_ampersand_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/crates/sickle/tests/test_data/api_fuzz_special_chars_seed49.json
+++ b/crates/sickle/tests/test_data/api_fuzz_special_chars_seed49.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -851,6 +852,31 @@
       "name": "s49_fuzz_val_epsilon_0_build_hierarchy",
       "source_test": "s49_fuzz_val_epsilon_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "epsilon": {
+            "data;x5&x96?x73": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "epsilon = data;x5&x96?x73"
+      ],
+      "name": "s49_fuzz_val_epsilon_0_build_model",
+      "source_test": "s49_fuzz_val_epsilon_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -913,6 +939,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -921,6 +948,31 @@
       "name": "s49_fuzz_val_config_1_build_hierarchy",
       "source_test": "s49_fuzz_val_config_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "data'x33": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config = data'x33"
+      ],
+      "name": "s49_fuzz_val_config_1_build_model",
+      "source_test": "s49_fuzz_val_config_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -983,6 +1035,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -991,6 +1044,31 @@
       "name": "s49_fuzz_val_name_2_build_hierarchy",
       "source_test": "s49_fuzz_val_name_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data<x71": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data<x71"
+      ],
+      "name": "s49_fuzz_val_name_2_build_model",
+      "source_test": "s49_fuzz_val_name_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1053,6 +1131,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1061,6 +1140,31 @@
       "name": "s49_fuzz_val_mode_3_build_hierarchy",
       "source_test": "s49_fuzz_val_mode_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mode": {
+            "data+x19": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mode = data+x19"
+      ],
+      "name": "s49_fuzz_val_mode_3_build_model",
+      "source_test": "s49_fuzz_val_mode_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1123,6 +1227,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1131,6 +1236,31 @@
       "name": "s49_fuzz_val_server_4_build_hierarchy",
       "source_test": "s49_fuzz_val_server_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "data#x70-x10": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server = data#x70-x10"
+      ],
+      "name": "s49_fuzz_val_server_4_build_model",
+      "source_test": "s49_fuzz_val_server_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1198,6 +1328,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1206,6 +1337,34 @@
       "name": "s49_fuzz_nested_squote_lbrace_0_build_hierarchy",
       "source_test": "s49_fuzz_nested_squote_lbrace_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "'name": {
+            "nested330": {}
+          },
+          "{user": {
+            "deep34": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "'name = nested330\n{user = deep34"
+      ],
+      "name": "s49_fuzz_nested_squote_lbrace_0_build_model",
+      "source_test": "s49_fuzz_nested_squote_lbrace_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1273,6 +1432,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1281,6 +1441,34 @@
       "name": "s49_fuzz_nested_at_underscore_1_build_hierarchy",
       "source_test": "s49_fuzz_nested_at_underscore_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "@name": {
+            "nested517": {}
+          },
+          "_user": {
+            "deep650": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "@name = nested517\n_user = deep650"
+      ],
+      "name": "s49_fuzz_nested_at_underscore_1_build_model",
+      "source_test": "s49_fuzz_nested_at_underscore_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1348,6 +1536,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1356,6 +1545,34 @@
       "name": "s49_fuzz_nested_rparen_backslash_2_build_hierarchy",
       "source_test": "s49_fuzz_nested_rparen_backslash_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")epsilon": {
+            "nested451": {}
+          },
+          "\\delta": {
+            "deep648": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ")epsilon = nested451\n\\delta = deep648"
+      ],
+      "name": "s49_fuzz_nested_rparen_backslash_2_build_model",
+      "source_test": "s49_fuzz_nested_rparen_backslash_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1423,6 +1640,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1431,6 +1649,34 @@
       "name": "s49_fuzz_nested_dollar_gt_3_build_hierarchy",
       "source_test": "s49_fuzz_nested_dollar_gt_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$port": {
+            "nested76": {}
+          },
+          ">host": {
+            "deep444": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "$port = nested76\n>host = deep444"
+      ],
+      "name": "s49_fuzz_nested_dollar_gt_3_build_model",
+      "source_test": "s49_fuzz_nested_dollar_gt_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1498,6 +1744,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1506,6 +1753,34 @@
       "name": "s49_fuzz_nested_dquote_lbrace_4_build_hierarchy",
       "source_test": "s49_fuzz_nested_dquote_lbrace_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"host": {
+            "nested587": {}
+          },
+          "{gamma": {
+            "deep774": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"host = nested587\n{gamma = deep774"
+      ],
+      "name": "s49_fuzz_nested_dquote_lbrace_4_build_model",
+      "source_test": "s49_fuzz_nested_dquote_lbrace_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1573,6 +1848,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1581,6 +1857,34 @@
       "name": "s49_fuzz_nested_semicolon_asterisk_5_build_hierarchy",
       "source_test": "s49_fuzz_nested_semicolon_asterisk_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "*item": {
+            "deep424": {}
+          },
+          ";host": {
+            "nested246": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ";host = nested246\n*item = deep424"
+      ],
+      "name": "s49_fuzz_nested_semicolon_asterisk_5_build_model",
+      "source_test": "s49_fuzz_nested_semicolon_asterisk_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1648,6 +1952,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1656,6 +1961,34 @@
       "name": "s49_fuzz_nested_question_asterisk_6_build_hierarchy",
       "source_test": "s49_fuzz_nested_question_asterisk_6",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "*delta": {
+            "deep689": {}
+          },
+          "?epsilon": {
+            "nested334": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "?epsilon = nested334\n*delta = deep689"
+      ],
+      "name": "s49_fuzz_nested_question_asterisk_6_build_model",
+      "source_test": "s49_fuzz_nested_question_asterisk_6",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1723,6 +2056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1731,6 +2065,34 @@
       "name": "s49_fuzz_nested_plus_ampersand_7_build_hierarchy",
       "source_test": "s49_fuzz_nested_plus_ampersand_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "&gamma": {
+            "deep440": {}
+          },
+          "+server": {
+            "nested496": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "+server = nested496\n&gamma = deep440"
+      ],
+      "name": "s49_fuzz_nested_plus_ampersand_7_build_model",
+      "source_test": "s49_fuzz_nested_plus_ampersand_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1798,6 +2160,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1806,6 +2169,34 @@
       "name": "s49_fuzz_nested_asterisk_dquote_8_build_hierarchy",
       "source_test": "s49_fuzz_nested_asterisk_dquote_8",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"delta": {
+            "deep232": {}
+          },
+          "*item": {
+            "nested578": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "*item = nested578\n\"delta = deep232"
+      ],
+      "name": "s49_fuzz_nested_asterisk_dquote_8_build_model",
+      "source_test": "s49_fuzz_nested_asterisk_dquote_8",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1873,6 +2264,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1881,6 +2273,34 @@
       "name": "s49_fuzz_nested_rbrace_slash_9_build_hierarchy",
       "source_test": "s49_fuzz_nested_rbrace_slash_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/delta": {
+            "deep756": {}
+          },
+          "}host": {
+            "nested668": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "}host = nested668\n/delta = deep756"
+      ],
+      "name": "s49_fuzz_nested_rbrace_slash_9_build_model",
+      "source_test": "s49_fuzz_nested_rbrace_slash_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/crates/sickle/tests/test_data/api_fuzz_special_chars_seed99.json
+++ b/crates/sickle/tests/test_data/api_fuzz_special_chars_seed99.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -851,6 +852,31 @@
       "name": "s99_fuzz_val_path_0_build_hierarchy",
       "source_test": "s99_fuzz_val_path_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "data'x66": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = data'x66"
+      ],
+      "name": "s99_fuzz_val_path_0_build_model",
+      "source_test": "s99_fuzz_val_path_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -913,6 +939,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -921,6 +948,31 @@
       "name": "s99_fuzz_val_item_1_build_hierarchy",
       "source_test": "s99_fuzz_val_item_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "data]x41!x78": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = data]x41!x78"
+      ],
+      "name": "s99_fuzz_val_item_1_build_model",
+      "source_test": "s99_fuzz_val_item_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -983,6 +1035,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -991,6 +1044,31 @@
       "name": "s99_fuzz_val_server_2_build_hierarchy",
       "source_test": "s99_fuzz_val_server_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "data[x73;x54!x24": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server = data[x73;x54!x24"
+      ],
+      "name": "s99_fuzz_val_server_2_build_model",
+      "source_test": "s99_fuzz_val_server_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1053,6 +1131,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1061,6 +1140,31 @@
       "name": "s99_fuzz_val_path_3_build_hierarchy",
       "source_test": "s99_fuzz_val_path_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "data~x4>x82~x46": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = data~x4>x82~x46"
+      ],
+      "name": "s99_fuzz_val_path_3_build_model",
+      "source_test": "s99_fuzz_val_path_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1123,6 +1227,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1131,6 +1236,31 @@
       "name": "s99_fuzz_val_alpha_4_build_hierarchy",
       "source_test": "s99_fuzz_val_alpha_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "alpha": {
+            "data<x11[x43": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "alpha = data<x11[x43"
+      ],
+      "name": "s99_fuzz_val_alpha_4_build_model",
+      "source_test": "s99_fuzz_val_alpha_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1198,6 +1328,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1206,6 +1337,34 @@
       "name": "s99_fuzz_nested_slash_rparen_0_build_hierarchy",
       "source_test": "s99_fuzz_nested_slash_rparen_0",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")item": {
+            "deep37": {}
+          },
+          "/data": {
+            "nested929": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/data = nested929\n)item = deep37"
+      ],
+      "name": "s99_fuzz_nested_slash_rparen_0_build_model",
+      "source_test": "s99_fuzz_nested_slash_rparen_0",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1273,6 +1432,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1281,6 +1441,34 @@
       "name": "s99_fuzz_nested_lt_percent_1_build_hierarchy",
       "source_test": "s99_fuzz_nested_lt_percent_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "%config": {
+            "deep795": {}
+          },
+          "<port": {
+            "nested722": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "<port = nested722\n%config = deep795"
+      ],
+      "name": "s99_fuzz_nested_lt_percent_1_build_model",
+      "source_test": "s99_fuzz_nested_lt_percent_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1348,6 +1536,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1356,6 +1545,34 @@
       "name": "s99_fuzz_nested_slash_lbrace_2_build_hierarchy",
       "source_test": "s99_fuzz_nested_slash_lbrace_2",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/epsilon": {
+            "nested268": {}
+          },
+          "{server": {
+            "deep795": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/epsilon = nested268\n{server = deep795"
+      ],
+      "name": "s99_fuzz_nested_slash_lbrace_2_build_model",
+      "source_test": "s99_fuzz_nested_slash_lbrace_2",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1423,6 +1640,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1431,6 +1649,34 @@
       "name": "s99_fuzz_nested_dquote_lbracket_3_build_hierarchy",
       "source_test": "s99_fuzz_nested_dquote_lbracket_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"host": {
+            "nested435": {}
+          },
+          "[server": {
+            "deep479": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"host = nested435\n[server = deep479"
+      ],
+      "name": "s99_fuzz_nested_dquote_lbracket_3_build_model",
+      "source_test": "s99_fuzz_nested_dquote_lbracket_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1498,6 +1744,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1506,6 +1753,34 @@
       "name": "s99_fuzz_nested_backslash_backslash_4_build_hierarchy",
       "source_test": "s99_fuzz_nested_backslash_backslash_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\\item": {
+            "nested708": {}
+          },
+          "\\name": {
+            "deep133": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\\item = nested708\n\\name = deep133"
+      ],
+      "name": "s99_fuzz_nested_backslash_backslash_4_build_model",
+      "source_test": "s99_fuzz_nested_backslash_backslash_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1573,6 +1848,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1581,6 +1857,34 @@
       "name": "s99_fuzz_nested_question_dquote_5_build_hierarchy",
       "source_test": "s99_fuzz_nested_question_dquote_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"item": {
+            "deep576": {}
+          },
+          "?delta": {
+            "nested18": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "?delta = nested18\n\"item = deep576"
+      ],
+      "name": "s99_fuzz_nested_question_dquote_5_build_model",
+      "source_test": "s99_fuzz_nested_question_dquote_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1648,6 +1952,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1656,6 +1961,34 @@
       "name": "s99_fuzz_nested_dquote_backslash_6_build_hierarchy",
       "source_test": "s99_fuzz_nested_dquote_backslash_6",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"user": {
+            "nested759": {}
+          },
+          "\\data": {
+            "deep718": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"user = nested759\n\\data = deep718"
+      ],
+      "name": "s99_fuzz_nested_dquote_backslash_6_build_model",
+      "source_test": "s99_fuzz_nested_dquote_backslash_6",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1723,6 +2056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1731,6 +2065,34 @@
       "name": "s99_fuzz_nested_rparen_backslash_7_build_hierarchy",
       "source_test": "s99_fuzz_nested_rparen_backslash_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")port": {
+            "nested292": {}
+          },
+          "\\server": {
+            "deep527": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ")port = nested292\n\\server = deep527"
+      ],
+      "name": "s99_fuzz_nested_rparen_backslash_7_build_model",
+      "source_test": "s99_fuzz_nested_rparen_backslash_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1798,6 +2160,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1806,6 +2169,34 @@
       "name": "s99_fuzz_nested_rbrace_dollar_8_build_hierarchy",
       "source_test": "s99_fuzz_nested_rbrace_dollar_8",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$gamma": {
+            "deep225": {}
+          },
+          "}delta": {
+            "nested591": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "}delta = nested591\n$gamma = deep225"
+      ],
+      "name": "s99_fuzz_nested_rbrace_dollar_8_build_model",
+      "source_test": "s99_fuzz_nested_rbrace_dollar_8",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1873,6 +2264,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1881,6 +2273,34 @@
       "name": "s99_fuzz_nested_percent_ampersand_9_build_hierarchy",
       "source_test": "s99_fuzz_nested_percent_ampersand_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "%epsilon": {
+            "nested761": {}
+          },
+          "&port": {
+            "deep211": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "%epsilon = nested761\n&port = deep211"
+      ],
+      "name": "s99_fuzz_nested_percent_ampersand_9_build_model",
+      "source_test": "s99_fuzz_nested_percent_ampersand_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/crates/sickle/tests/test_data/api_list_access.json
+++ b/crates/sickle/tests/test_data/api_list_access.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -46,6 +46,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -54,6 +55,31 @@
       "name": "basic_list_from_duplicates_build_hierarchy",
       "source_test": "basic_list_from_duplicates",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "servers": {
+            "web1": {},
+            "web2": {},
+            "web3": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers = web1\nservers = web2\nservers = web3"
+      ],
+      "name": "basic_list_from_duplicates_build_model",
+      "source_test": "basic_list_from_duplicates",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -218,6 +244,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -226,6 +253,48 @@
       "name": "large_list_build_hierarchy",
       "source_test": "large_list",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "item01": {},
+            "item02": {},
+            "item03": {},
+            "item04": {},
+            "item05": {},
+            "item06": {},
+            "item07": {},
+            "item08": {},
+            "item09": {},
+            "item10": {},
+            "item11": {},
+            "item12": {},
+            "item13": {},
+            "item14": {},
+            "item15": {},
+            "item16": {},
+            "item17": {},
+            "item18": {},
+            "item19": {},
+            "item20": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items = item01\nitems = item02\nitems = item03\nitems = item04\nitems = item05\nitems = item06\nitems = item07\nitems = item08\nitems = item09\nitems = item10\nitems = item11\nitems = item12\nitems = item13\nitems = item14\nitems = item15\nitems = item16\nitems = item17\nitems = item18\nitems = item19\nitems = item20"
+      ],
+      "name": "large_list_build_model",
+      "source_test": "large_list",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -345,6 +414,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -353,6 +423,37 @@
       "name": "list_with_comments_build_hierarchy",
       "source_test": "list_with_comments",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "End of list": {},
+            "Production servers": {}
+          },
+          "servers": {
+            "web1": {},
+            "web2": {},
+            "web3": {}
+          }
+        }
+      },
+      "features": [
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers = web1\n/= Production servers\nservers = web2\nservers = web3\n/= End of list"
+      ],
+      "name": "list_with_comments_build_model",
+      "source_test": "list_with_comments",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -459,6 +560,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -467,6 +569,37 @@
       "name": "list_with_comments_lexicographic_build_hierarchy",
       "source_test": "list_with_comments_lexicographic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "End of list": {},
+            "Production servers": {}
+          },
+          "servers": {
+            "web1": {},
+            "web2": {},
+            "web3": {}
+          }
+        }
+      },
+      "features": [
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers = web1\n/= Production servers\nservers = web2\nservers = web3\n/= End of list"
+      ],
+      "name": "list_with_comments_lexicographic_build_model",
+      "source_test": "list_with_comments_lexicographic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -538,6 +671,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -546,6 +680,29 @@
       "name": "list_error_missing_key_build_hierarchy",
       "source_test": "list_error_missing_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "existing": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "existing = value"
+      ],
+      "name": "list_error_missing_key_build_model",
+      "source_test": "list_error_missing_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -603,6 +760,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -611,6 +769,31 @@
       "name": "list_error_nested_missing_key_build_hierarchy",
       "source_test": "list_error_nested_missing_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "server": {
+              "web1": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  server = web1"
+      ],
+      "name": "list_error_nested_missing_key_build_model",
+      "source_test": "list_error_nested_missing_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -667,6 +850,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -675,6 +859,29 @@
       "name": "list_error_non_object_path_build_hierarchy",
       "source_test": "list_error_non_object_path",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "value": {
+            "simple": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "value = simple"
+      ],
+      "name": "list_error_non_object_path_build_model",
+      "source_test": "list_error_non_object_path",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -723,6 +930,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -731,6 +939,25 @@
       "name": "list_edge_case_zero_length_build_hierarchy",
       "source_test": "list_edge_case_zero_length",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {}
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ""
+      ],
+      "name": "list_edge_case_zero_length_build_model",
+      "source_test": "list_edge_case_zero_length",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -796,6 +1023,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -804,6 +1032,35 @@
       "name": "bare_list_basic_build_hierarchy",
       "source_test": "bare_list_basic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "servers": {
+            "": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  = web1\n  = web2\n  = web3"
+      ],
+      "name": "bare_list_basic_build_model",
+      "source_test": "bare_list_basic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -885,6 +1142,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -896,12 +1154,44 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "network": {
+            "ports": {
+              "": {
+                "443": {},
+                "80": {},
+                "8080": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
+      ],
+      "name": "bare_list_nested_build_model",
+      "source_test": "bare_list_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "network",
         "ports"
       ],
       "behaviors": [
-        "array_order_insertion"
+        "array_order_insertion",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -982,6 +1272,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -993,12 +1284,44 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "network": {
+            "ports": {
+              "": {
+                "443": {},
+                "80": {},
+                "8080": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
+      ],
+      "name": "bare_list_nested_lexicographic_build_model",
+      "source_test": "bare_list_nested_lexicographic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "network",
         "ports"
       ],
       "behaviors": [
-        "array_order_lexicographic"
+        "array_order_lexicographic",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -1080,6 +1403,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1088,6 +1412,39 @@
       "name": "bare_list_with_comments_build_hierarchy",
       "source_test": "bare_list_with_comments",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "allowed_hosts": {
+            "": {
+              "127.0.0.1": {},
+              "example.com": {},
+              "localhost": {}
+            },
+            "/": {
+              "Production hosts": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "allowed_hosts =\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
+      ],
+      "name": "bare_list_with_comments_build_model",
+      "source_test": "bare_list_with_comments",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1178,6 +1535,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1186,6 +1544,39 @@
       "name": "bare_list_with_comments_lexicographic_build_hierarchy",
       "source_test": "bare_list_with_comments_lexicographic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "allowed_hosts": {
+            "": {
+              "127.0.0.1": {},
+              "example.com": {},
+              "localhost": {}
+            },
+            "/": {
+              "Production hosts": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "allowed_hosts =\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
+      ],
+      "name": "bare_list_with_comments_lexicographic_build_model",
+      "source_test": "bare_list_with_comments_lexicographic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1279,6 +1670,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1290,6 +1682,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "environments": {
+              "production": {
+                "servers": {
+                  "": {
+                    "api1": {},
+                    "web1": {},
+                    "web2": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
+      ],
+      "name": "bare_list_deeply_nested_build_model",
+      "source_test": "bare_list_deeply_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "environments",
@@ -1297,7 +1724,8 @@
         "servers"
       ],
       "behaviors": [
-        "array_order_insertion"
+        "array_order_insertion",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -1382,6 +1810,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1393,6 +1822,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "environments": {
+              "production": {
+                "servers": {
+                  "": {
+                    "api1": {},
+                    "web1": {},
+                    "web2": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
+      ],
+      "name": "bare_list_deeply_nested_lexicographic_build_model",
+      "source_test": "bare_list_deeply_nested_lexicographic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "environments",
@@ -1400,7 +1864,8 @@
         "servers"
       ],
       "behaviors": [
-        "array_order_lexicographic"
+        "array_order_lexicographic",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -1475,6 +1940,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1486,11 +1952,49 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "5432": {}
+            },
+            "replicas": {
+              "": {
+                "replica1": {},
+                "replica2": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  port = 5432\n  replicas =\n    = replica1\n    = replica2"
+      ],
+      "name": "bare_list_mixed_with_other_keys_build_model",
+      "source_test": "bare_list_mixed_with_other_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "database",
         "replicas"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "path_traversal"
+      ],
       "expected": {
         "count": 2,
         "list": [
@@ -1547,6 +2051,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1558,12 +2063,38 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "setting": {
+              "value": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  setting = value"
+      ],
+      "name": "bare_list_error_not_a_list_build_model",
+      "source_test": "bare_list_error_not_a_list",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "setting"
       ],
       "behaviors": [
-        "list_coercion_disabled"
+        "list_coercion_disabled",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -1633,6 +2164,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1641,6 +2173,40 @@
       "name": "bare_list_nested_objects_basic_build_hierarchy",
       "source_test": "bare_list_nested_objects_basic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {
+              "name": {
+                "first": {},
+                "second": {}
+              },
+              "value": {
+                "1": {},
+                "2": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
+      ],
+      "name": "bare_list_nested_objects_basic_build_model",
+      "source_test": "bare_list_nested_objects_basic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1719,6 +2285,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1727,6 +2294,38 @@
       "name": "bare_list_nested_objects_single_item_build_hierarchy",
       "source_test": "bare_list_nested_objects_single_item",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {
+              "name": {
+                "only": {}
+              },
+              "value": {
+                "42": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =\n  =\n    name = only\n    value = 42"
+      ],
+      "name": "bare_list_nested_objects_single_item_build_model",
+      "source_test": "bare_list_nested_objects_single_item",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1803,6 +2402,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1811,6 +2411,36 @@
       "name": "bare_list_nested_objects_minimal_build_hierarchy",
       "source_test": "bare_list_nested_objects_minimal",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {
+              "name": {
+                "first": {},
+                "second": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =\n  =\n    name = first\n  =\n    name = second"
+      ],
+      "name": "bare_list_nested_objects_minimal_build_model",
+      "source_test": "bare_list_nested_objects_minimal",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1865,6 +2495,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1873,6 +2504,42 @@
       "name": "bare_list_nested_objects_deeply_nested_build_hierarchy",
       "source_test": "bare_list_nested_objects_deeply_nested",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {
+              "config": {
+                "host": {
+                  "example.com": {},
+                  "localhost": {}
+                },
+                "port": {
+                  "443": {},
+                  "8080": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =\n  =\n    config =\n      host = localhost\n      port = 8080\n  =\n    config =\n      host = example.com\n      port = 443"
+      ],
+      "name": "bare_list_nested_objects_deeply_nested_build_model",
+      "source_test": "bare_list_nested_objects_deeply_nested",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1928,6 +2595,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1936,6 +2604,40 @@
       "name": "bare_list_nested_objects_mixed_with_strings_build_hierarchy",
       "source_test": "bare_list_nested_objects_mixed_with_strings",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {
+              "another_string": {},
+              "name": {
+                "nested": {}
+              },
+              "simple_string": {},
+              "value": {
+                "obj": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =\n  = simple_string\n  =\n    name = nested\n    value = obj\n  = another_string"
+      ],
+      "name": "bare_list_nested_objects_mixed_with_strings_build_model",
+      "source_test": "bare_list_nested_objects_mixed_with_strings",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/crates/sickle/tests/test_data/api_proposed_behavior.json
+++ b/crates/sickle/tests/test_data/api_proposed_behavior.json
@@ -1,8 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -18,7 +20,7 @@
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented"
@@ -29,8 +31,38 @@
       "name": "multiline_section_header_value_parse_indented",
       "source_test": "multiline_section_header_value",
       "validation": "parse_indented",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "",
+            "value": "= Section Header ="
+          },
+          {
+            "key": "prefix for next key\nkey",
+            "value": "value"
+          }
+        ]
+      },
+      "features": [
+        "empty_keys",
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "== Section Header =\nprefix for next key\nkey = value"
+      ],
+      "name": "unindented_line_does_not_continue_value_parse",
+      "source_test": "unindented_line_does_not_continue_value",
+      "validation": "parse",
       "variants": [
-        "proposed_behavior"
+        "reference_compliant"
       ]
     },
     {
@@ -40,32 +72,35 @@
         "entries": [
           {
             "key": "",
-            "value": "= Section Header =\nThis continues the header"
+            "value": "= Section Header ="
           },
           {
-            "key": "key",
+            "key": "prefix for next key\nkey",
             "value": "value"
           }
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "multiline_keys"
       ],
       "functions": [
         "parse_indented"
       ],
       "inputs": [
-        "== Section Header =\nThis continues the header\nkey = value"
+        "== Section Header =\nprefix for next key\nkey = value"
       ],
-      "name": "unindented_multiline_becomes_continuation_parse_indented",
-      "source_test": "unindented_multiline_becomes_continuation",
+      "name": "unindented_line_does_not_continue_value_parse_indented",
+      "source_test": "unindented_line_does_not_continue_value",
       "validation": "parse_indented",
       "variants": [
-        "proposed_behavior"
+        "reference_compliant"
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -80,7 +115,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented"
@@ -91,12 +126,18 @@
       "name": "indented_line_is_continuation_parse_indented",
       "source_test": "indented_line_is_continuation",
       "validation": "parse_indented",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion",
+        "multiline_values"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -107,9 +148,10 @@
         }
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -118,19 +160,47 @@
       "name": "indented_line_is_continuation_build_hierarchy",
       "source_test": "indented_line_is_continuation",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "expected": {
+        "count": 1,
+        "object": {
+          "descriptions": {
+            "Another item": {},
+            "First line\n  second line": {}
+          }
+        }
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "descriptions = First line\n  second line\ndescriptions = Another item"
+      ],
+      "name": "indented_line_is_continuation_build_model",
+      "source_test": "indented_line_is_continuation",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "descriptions"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -142,7 +212,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "get_list"
@@ -153,78 +223,7 @@
       "name": "indented_line_is_continuation_get_list",
       "source_test": "indented_line_is_continuation",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
-    },
-    {
-      "behaviors": [],
-      "expected": {
-        "count": 4,
-        "entries": [
-          {
-            "key": "key1",
-            "value": "value1\n  indented continuation"
-          },
-          {
-            "key": "key2",
-            "value": "value2"
-          },
-          {
-            "key": "not indented key",
-            "value": ""
-          },
-          {
-            "key": "indented for not indented",
-            "value": ""
-          }
-        ]
-      },
-      "features": [
-        "multiline",
-        "empty_keys"
-      ],
-      "functions": [
-        "parse_indented"
-      ],
-      "inputs": [
-        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
-      ],
-      "name": "mixed_indentation_levels_parse_indented",
-      "source_test": "mixed_indentation_levels",
-      "validation": "parse_indented",
-      "variants": [
-        "proposed_behavior"
-      ]
-    },
-    {
-      "behaviors": [],
-      "expected": {
-        "count": 1,
-        "object": {
-          "key1": "value1\n  indented continuation",
-          "key2": "value2",
-          "not indented key": {
-            "indented for not indented": ""
-          }
-        }
-      },
-      "features": [
-        "multiline",
-        "empty_keys"
-      ],
-      "functions": [
-        "build_hierarchy"
-      ],
-      "inputs": [
-        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
-      ],
-      "name": "mixed_indentation_levels_build_hierarchy",
-      "source_test": "mixed_indentation_levels",
-      "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -247,9 +246,7 @@
       "name": "single_item_as_list_parse",
       "source_test": "single_item_as_list",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -261,6 +258,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -269,9 +267,30 @@
       "name": "single_item_as_list_build_hierarchy",
       "source_test": "single_item_as_list",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "single": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = single"
+      ],
+      "name": "single_item_as_list_build_model",
+      "source_test": "single_item_as_list",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
@@ -301,9 +320,7 @@
       "name": "single_item_as_list_get_list",
       "source_test": "single_item_as_list",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -334,12 +351,17 @@
       "name": "mixed_duplicate_single_keys_parse",
       "source_test": "mixed_duplicate_single_keys",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -352,6 +374,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -360,19 +383,46 @@
       "name": "mixed_duplicate_single_keys_build_hierarchy",
       "source_test": "mixed_duplicate_single_keys",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": {
+            "localhost": {}
+          },
+          "ports": {
+            "443": {},
+            "80": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "ports = 80\nports = 443\nhost = localhost"
+      ],
+      "name": "mixed_duplicate_single_keys_build_model",
+      "source_test": "mixed_duplicate_single_keys",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "host"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -392,9 +442,7 @@
       "name": "mixed_duplicate_single_keys_get_list",
       "source_test": "mixed_duplicate_single_keys",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -417,9 +465,7 @@
       "name": "nested_list_access_parse",
       "source_test": "nested_list_access",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -437,6 +483,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -445,9 +492,36 @@
       "name": "nested_list_access_build_hierarchy",
       "source_test": "nested_list_access",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "hosts": {
+              "primary": {},
+              "secondary": {}
+            },
+            "port": {
+              "5432": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
+      ],
+      "name": "nested_list_access_build_model",
+      "source_test": "nested_list_access",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
@@ -455,7 +529,8 @@
         "port"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -478,9 +553,7 @@
       "name": "nested_list_access_get_list",
       "source_test": "nested_list_access",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -503,12 +576,17 @@
       "name": "empty_list_parse",
       "source_test": "empty_list",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -517,6 +595,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -525,19 +604,42 @@
       "name": "empty_list_build_hierarchy",
       "source_test": "empty_list",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "empty_list": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_list ="
+      ],
+      "name": "empty_list_build_model",
+      "source_test": "empty_list",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "empty_list"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -557,9 +659,7 @@
       "name": "empty_list_get_list",
       "source_test": "empty_list",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -594,12 +694,17 @@
       "name": "list_with_numbers_parse",
       "source_test": "list_with_numbers",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -613,6 +718,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -621,19 +727,45 @@
       "name": "list_with_numbers_build_hierarchy",
       "source_test": "list_with_numbers",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "numbers": {
+            "-17": {},
+            "0": {},
+            "1": {},
+            "42": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
+      ],
+      "name": "list_with_numbers_build_model",
+      "source_test": "list_with_numbers",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "numbers"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -656,9 +788,7 @@
       "name": "list_with_numbers_get_list",
       "source_test": "list_with_numbers",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -693,12 +823,17 @@
       "name": "list_with_booleans_parse",
       "source_test": "list_with_booleans",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -712,6 +847,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -720,19 +856,45 @@
       "name": "list_with_booleans_build_hierarchy",
       "source_test": "list_with_booleans",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flags": {
+            "false": {},
+            "no": {},
+            "true": {},
+            "yes": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flags = true\nflags = false\nflags = yes\nflags = no"
+      ],
+      "name": "list_with_booleans_build_model",
+      "source_test": "list_with_booleans",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "flags"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -755,9 +917,7 @@
       "name": "list_with_booleans_get_list",
       "source_test": "list_with_booleans",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -794,12 +954,17 @@
       "name": "list_with_whitespace_parse",
       "source_test": "list_with_whitespace",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -815,6 +980,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -823,19 +989,46 @@
       "name": "list_with_whitespace_build_hierarchy",
       "source_test": "list_with_whitespace",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {},
+            "normal": {},
+            "spaced": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =   spaced   \nitems = normal\nitems =\nitems =   "
+      ],
+      "name": "list_with_whitespace_build_model",
+      "source_test": "list_with_whitespace",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "items"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -860,9 +1053,7 @@
       "name": "list_with_whitespace_get_list",
       "source_test": "list_with_whitespace",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -899,12 +1090,17 @@
       "name": "list_with_unicode_parse",
       "source_test": "list_with_unicode",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -920,6 +1116,7 @@
         "unicode"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -928,19 +1125,47 @@
       "name": "list_with_unicode_build_hierarchy",
       "source_test": "list_with_unicode",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "names": {
+            "François": {},
+            "José": {},
+            "العربية": {},
+            "张三": {}
+          }
+        }
+      },
+      "features": [
+        "unicode"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "names = 张三\nnames = José\nnames = François\nnames = العربية"
+      ],
+      "name": "list_with_unicode_build_model",
+      "source_test": "list_with_unicode",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "names"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -965,9 +1190,7 @@
       "name": "list_with_unicode_get_list",
       "source_test": "list_with_unicode",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -1002,12 +1225,17 @@
       "name": "list_with_special_characters_parse",
       "source_test": "list_with_special_characters",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1021,6 +1249,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1029,19 +1258,45 @@
       "name": "list_with_special_characters_build_hierarchy",
       "source_test": "list_with_special_characters",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "symbols": {
+            "!^&*()": {},
+            "<>=+": {},
+            "@#$%": {},
+            "[]{}|": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "symbols = @#$%\nsymbols = !^&*()\nsymbols = []{}|\nsymbols = <>=+"
+      ],
+      "name": "list_with_special_characters_build_model",
+      "source_test": "list_with_special_characters",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "symbols"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -1064,12 +1319,12 @@
       "name": "list_with_special_characters_get_list",
       "source_test": "list_with_special_characters",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 4,
         "entries": [
@@ -1092,7 +1347,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented"
@@ -1103,12 +1358,18 @@
       "name": "list_multiline_values_parse_indented",
       "source_test": "list_multiline_values",
       "validation": "parse_indented",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion",
+        "multiline_values"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1121,9 +1382,10 @@
         }
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1132,19 +1394,51 @@
       "name": "list_multiline_values_build_hierarchy",
       "source_test": "list_multiline_values",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "expected": {
+        "count": 1,
+        "object": {
+          "descriptions": {
+            "Another item": {},
+            "First line": {},
+            "Third item": {}
+          },
+          "second line": {
+            "": {}
+          }
+        }
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "descriptions = First line\nsecond line\ndescriptions = Another item\ndescriptions = Third item"
+      ],
+      "name": "list_multiline_values_build_model",
+      "source_test": "list_multiline_values",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "descriptions"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -1157,7 +1451,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "get_list"
@@ -1168,46 +1462,16 @@
       "name": "list_multiline_values_get_list",
       "source_test": "list_multiline_values",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
       "expected": {
-        "count": 11,
+        "count": 4,
         "entries": [
           {
             "key": "config",
-            "value": ""
-          },
-          {
-            "key": "servers",
-            "value": "web1"
-          },
-          {
-            "key": "servers",
-            "value": "web2"
-          },
-          {
-            "key": "database",
-            "value": ""
-          },
-          {
-            "key": "hosts",
-            "value": "primary"
-          },
-          {
-            "key": "hosts",
-            "value": "backup"
-          },
-          {
-            "key": "port",
-            "value": "5432"
-          },
-          {
-            "key": "cache",
-            "value": "redis"
+            "value": "\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis"
           },
           {
             "key": "features",
@@ -1233,12 +1497,17 @@
       "name": "complex_mixed_list_scenarios_parse_indented",
       "source_test": "complex_mixed_list_scenarios",
       "validation": "parse_indented",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1265,6 +1534,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1273,19 +1543,63 @@
       "name": "complex_mixed_list_scenarios_build_hierarchy",
       "source_test": "complex_mixed_list_scenarios",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "cache": {
+              "redis": {}
+            },
+            "database": {
+              "hosts": {
+                "backup": {},
+                "primary": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            },
+            "servers": {
+              "web1": {},
+              "web2": {}
+            }
+          },
+          "features": {
+            "api": {},
+            "auth": {},
+            "ui": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
+      ],
+      "name": "complex_mixed_list_scenarios_build_model",
+      "source_test": "complex_mixed_list_scenarios",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
         "features"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -1307,9 +1621,7 @@
       "name": "complex_mixed_list_scenarios_get_list",
       "source_test": "complex_mixed_list_scenarios",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -1332,9 +1644,7 @@
       "name": "list_path_traversal_protection_parse",
       "source_test": "list_path_traversal_protection",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -1346,6 +1656,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1354,9 +1665,30 @@
       "name": "list_path_traversal_protection_build_hierarchy",
       "source_test": "list_path_traversal_protection",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "safe": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "safe = value"
+      ],
+      "name": "list_path_traversal_protection_build_model",
+      "source_test": "list_path_traversal_protection",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
@@ -1386,9 +1718,7 @@
       "name": "list_path_traversal_protection_get_list",
       "source_test": "list_path_traversal_protection",
       "validation": "get_list",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -1411,9 +1741,7 @@
       "name": "parse_empty_value_parse",
       "source_test": "parse_empty_value",
       "validation": "parse",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     },
     {
       "behaviors": [],
@@ -1425,6 +1753,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1433,9 +1762,30 @@
       "name": "parse_empty_value_build_hierarchy",
       "source_test": "parse_empty_value",
       "validation": "build_hierarchy",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "empty_key": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_key ="
+      ],
+      "name": "parse_empty_value_build_model",
+      "source_test": "parse_empty_value",
+      "validation": "build_model",
+      "variants": []
     },
     {
       "args": [
@@ -1456,9 +1806,7 @@
       "name": "parse_empty_value_get_string",
       "source_test": "parse_empty_value",
       "validation": "get_string",
-      "variants": [
-        "proposed_behavior"
-      ]
+      "variants": []
     }
   ]
 }

--- a/crates/sickle/tests/test_data/api_reference_compliant.json
+++ b/crates/sickle/tests/test_data/api_reference_compliant.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -36,6 +36,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -44,6 +45,31 @@
       "name": "single_item_as_list_reference_build_hierarchy",
       "source_test": "single_item_as_list_reference",
       "validation": "build_hierarchy",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "single": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = single"
+      ],
+      "name": "single_item_as_list_reference_build_model",
+      "source_test": "single_item_as_list_reference",
+      "validation": "build_model",
       "variants": [
         "reference_compliant"
       ]
@@ -129,6 +155,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -137,6 +164,33 @@
       "name": "mixed_duplicate_single_keys_reference_build_hierarchy",
       "source_test": "mixed_duplicate_single_keys_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": {
+            "localhost": {}
+          },
+          "ports": {
+            "443": {},
+            "80": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "ports = 80\nports = 443\nhost = localhost"
+      ],
+      "name": "mixed_duplicate_single_keys_reference_build_model",
+      "source_test": "mixed_duplicate_single_keys_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -209,6 +263,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -222,12 +277,44 @@
       ]
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "hosts": {
+              "primary": {},
+              "secondary": {}
+            },
+            "port": {
+              "5432": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
+      ],
+      "name": "nested_list_access_reference_build_model",
+      "source_test": "nested_list_access_reference",
+      "validation": "build_model",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
       "args": [
         "database",
         "port"
       ],
       "behaviors": [
-        "list_coercion_disabled"
+        "list_coercion_disabled",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -286,6 +373,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -294,6 +382,31 @@
       "name": "empty_list_reference_build_hierarchy",
       "source_test": "empty_list_reference",
       "validation": "build_hierarchy",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "empty_list": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_list ="
+      ],
+      "name": "empty_list_reference_build_model",
+      "source_test": "empty_list_reference",
+      "validation": "build_model",
       "variants": [
         "reference_compliant"
       ]
@@ -377,6 +490,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -385,6 +499,32 @@
       "name": "list_with_numbers_reference_build_hierarchy",
       "source_test": "list_with_numbers_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "numbers": {
+            "-17": {},
+            "0": {},
+            "1": {},
+            "42": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
+      ],
+      "name": "list_with_numbers_reference_build_model",
+      "source_test": "list_with_numbers_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -473,6 +613,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -481,6 +622,32 @@
       "name": "list_with_booleans_reference_build_hierarchy",
       "source_test": "list_with_booleans_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flags": {
+            "false": {},
+            "no": {},
+            "true": {},
+            "yes": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flags = true\nflags = false\nflags = yes\nflags = no"
+      ],
+      "name": "list_with_booleans_reference_build_model",
+      "source_test": "list_with_booleans_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -536,6 +703,7 @@
         ]
       },
       "features": [
+        "empty_keys",
         "whitespace"
       ],
       "functions": [
@@ -562,15 +730,19 @@
         "count": 1,
         "object": {
           "items": [
+            "",
+            "",
             "normal",
             "spaced"
           ]
         }
       },
       "features": [
+        "empty_keys",
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -579,6 +751,34 @@
       "name": "list_with_whitespace_reference_build_hierarchy",
       "source_test": "list_with_whitespace_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {},
+            "normal": {},
+            "spaced": {}
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =   spaced   \nitems = normal\nitems =\nitems =   "
+      ],
+      "name": "list_with_whitespace_reference_build_model",
+      "source_test": "list_with_whitespace_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -599,6 +799,7 @@
         "count": 0
       },
       "features": [
+        "empty_keys",
         "whitespace"
       ],
       "functions": [
@@ -673,6 +874,7 @@
         "unicode"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -681,6 +883,34 @@
       "name": "list_with_unicode_reference_build_hierarchy",
       "source_test": "list_with_unicode_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "names": {
+            "François": {},
+            "José": {},
+            "العربية": {},
+            "张三": {}
+          }
+        }
+      },
+      "features": [
+        "unicode"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "names = 张三\nnames = José\nnames = François\nnames = العربية"
+      ],
+      "name": "list_with_unicode_reference_build_model",
+      "source_test": "list_with_unicode_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -766,6 +996,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -774,6 +1005,31 @@
       "name": "list_with_special_characters_reference_build_hierarchy",
       "source_test": "list_with_special_characters_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "symbols": {
+            "!^&*()": {},
+            "@#$%": {},
+            "[]{}|": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "symbols = @#$%\nsymbols = !^&*()\nsymbols = []{}|"
+      ],
+      "name": "list_with_special_characters_reference_build_model",
+      "source_test": "list_with_special_characters_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -840,6 +1096,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -851,12 +1108,56 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "cache": {
+              "redis": {}
+            },
+            "database": {
+              "hosts": {
+                "backup": {},
+                "primary": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            },
+            "servers": {
+              "web1": {},
+              "web2": {}
+            }
+          },
+          "features": {
+            "api": {},
+            "auth": {},
+            "ui": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
+      ],
+      "name": "complex_mixed_list_scenarios_reference_build_model",
+      "source_test": "complex_mixed_list_scenarios_reference",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "features"
       ],
       "behaviors": [
         "list_coercion_disabled",
-        "array_order_lexicographic"
+        "array_order_lexicographic",
+        "path_traversal"
       ],
       "conflicts": {
         "behaviors": [
@@ -914,6 +1215,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -922,6 +1224,31 @@
       "name": "list_path_traversal_protection_reference_build_hierarchy",
       "source_test": "list_path_traversal_protection_reference",
       "validation": "build_hierarchy",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "safe": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "safe = value"
+      ],
+      "name": "list_path_traversal_protection_reference_build_model",
+      "source_test": "list_path_traversal_protection_reference",
+      "validation": "build_model",
       "variants": [
         "reference_compliant"
       ]
@@ -990,6 +1317,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1006,12 +1334,38 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "empty_key": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_key ="
+      ],
+      "name": "empty_value_reference_behavior_build_model",
+      "source_test": "empty_value_reference_behavior",
+      "validation": "build_model",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "value": "empty_key =\n"
       },
       "features": [],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "empty_key ="
@@ -1019,40 +1373,17 @@
       "name": "canonical_format_empty_values_ocaml_reference_canonical_format",
       "source_test": "canonical_format_empty_values_ocaml_reference",
       "validation": "canonical_format",
-      "variants": [
-        "reference_compliant"
-      ]
+      "variants": []
     },
     {
       "behaviors": [
-        "tabs_as_content"
+        "indent_spaces"
       ],
       "conflicts": {
         "behaviors": [
-          "tabs_as_whitespace"
+          "indent_tabs"
         ]
       },
-      "expected": {
-        "count": 1,
-        "value": "value_with_tabs =\n  text\t\twith\ttabs =\n"
-      },
-      "features": [],
-      "functions": [
-        "parse",
-        "print"
-      ],
-      "inputs": [
-        "value_with_tabs = text\t\twith\ttabs\t"
-      ],
-      "name": "canonical_format_tab_preservation_ocaml_reference_canonical_format",
-      "source_test": "canonical_format_tab_preservation_ocaml_reference",
-      "validation": "canonical_format",
-      "variants": [
-        "reference_compliant"
-      ]
-    },
-    {
-      "behaviors": [],
       "expected": {
         "count": 1,
         "value": "emo =\n  🌟✨ =\nunicode =\n  你好世界 =\n"
@@ -1062,7 +1393,8 @@
       ],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "unicode = 你好世界\nemo = 🌟✨"
@@ -1070,9 +1402,7 @@
       "name": "canonical_format_unicode_ocaml_reference_canonical_format",
       "source_test": "canonical_format_unicode_ocaml_reference",
       "validation": "canonical_format",
-      "variants": [
-        "reference_compliant"
-      ]
+      "variants": []
     },
     {
       "behaviors": [
@@ -1106,17 +1436,17 @@
       "name": "canonical_format_line_endings_reference_behavior_parse",
       "source_test": "canonical_format_line_endings_reference_behavior",
       "validation": "parse",
-      "variants": [
-        "reference_compliant"
-      ]
+      "variants": []
     },
     {
       "behaviors": [
-        "crlf_preserve_literal"
+        "crlf_preserve_literal",
+        "indent_spaces"
       ],
       "conflicts": {
         "behaviors": [
-          "crlf_normalize_to_lf"
+          "crlf_normalize_to_lf",
+          "indent_tabs"
         ]
       },
       "expected": {
@@ -1126,7 +1456,8 @@
       "features": [],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "key1 = value1\r\nkey2 = value2\r\n"
@@ -1134,12 +1465,17 @@
       "name": "canonical_format_line_endings_reference_behavior_canonical_format",
       "source_test": "canonical_format_line_endings_reference_behavior",
       "validation": "canonical_format",
-      "variants": [
-        "reference_compliant"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "indent_spaces"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "key1 =\n  value1 =\nkey2 =\n  value2 =\nkey3 =\n  value3 =\n"
@@ -1147,7 +1483,8 @@
       "features": [],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "key1=value1\nkey2  =  value2\nkey3\t=\tvalue3"
@@ -1155,12 +1492,17 @@
       "name": "canonical_format_consistent_spacing_ocaml_reference_canonical_format",
       "source_test": "canonical_format_consistent_spacing_ocaml_reference",
       "validation": "canonical_format",
-      "variants": [
-        "reference_compliant"
-      ]
+      "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "indent_spaces"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "a =\n  first =\nm =\n  middle =\nz =\n  last =\n"
@@ -1168,7 +1510,8 @@
       "features": [],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "z = last\na = first\nm = middle"
@@ -1176,9 +1519,7 @@
       "name": "deterministic_output_ocaml_reference_canonical_format",
       "source_test": "deterministic_output_ocaml_reference",
       "validation": "canonical_format",
-      "variants": [
-        "reference_compliant"
-      ]
+      "variants": []
     }
   ]
 }

--- a/crates/sickle/tests/test_data/api_typed_access.json
+++ b/crates/sickle/tests/test_data/api_typed_access.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -38,6 +38,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -46,6 +47,31 @@
       "name": "parse_basic_integer_build_hierarchy",
       "source_test": "parse_basic_integer",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "port": {
+            "8080": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "port = 8080"
+      ],
+      "name": "parse_basic_integer_build_model",
+      "source_test": "parse_basic_integer",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -108,6 +134,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -116,6 +143,31 @@
       "name": "parse_basic_float_build_hierarchy",
       "source_test": "parse_basic_float",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "temperature": {
+            "98.6": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "temperature = 98.6"
+      ],
+      "name": "parse_basic_float_build_model",
+      "source_test": "parse_basic_float",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -178,6 +230,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -186,6 +239,31 @@
       "name": "parse_boolean_true_build_hierarchy",
       "source_test": "parse_boolean_true",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "enabled": {
+            "true": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "enabled = true"
+      ],
+      "name": "parse_boolean_true_build_model",
+      "source_test": "parse_boolean_true",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -257,6 +335,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -265,6 +344,31 @@
       "name": "parse_boolean_yes_build_hierarchy",
       "source_test": "parse_boolean_yes",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "active": {
+            "yes": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "active = yes"
+      ],
+      "name": "parse_boolean_yes_build_model",
+      "source_test": "parse_boolean_yes",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -334,6 +438,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -342,6 +447,31 @@
       "name": "parse_boolean_yes_strict_literal_build_hierarchy",
       "source_test": "parse_boolean_yes_strict_literal",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "active": {
+            "yes": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "active = yes"
+      ],
+      "name": "parse_boolean_yes_strict_literal_build_model",
+      "source_test": "parse_boolean_yes_strict_literal",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -410,6 +540,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -418,6 +549,31 @@
       "name": "parse_boolean_false_build_hierarchy",
       "source_test": "parse_boolean_false",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "disabled": {
+            "false": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "disabled = false"
+      ],
+      "name": "parse_boolean_false_build_model",
+      "source_test": "parse_boolean_false",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -485,6 +641,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -493,6 +650,29 @@
       "name": "parse_string_fallback_build_hierarchy",
       "source_test": "parse_string_fallback",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "Alice": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice"
+      ],
+      "name": "parse_string_fallback_build_model",
+      "source_test": "parse_string_fallback",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -553,6 +733,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -561,6 +742,31 @@
       "name": "parse_negative_integer_build_hierarchy",
       "source_test": "parse_negative_integer",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "offset": {
+            "-42": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "offset = -42"
+      ],
+      "name": "parse_negative_integer_build_model",
+      "source_test": "parse_negative_integer",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -635,6 +841,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -643,6 +850,38 @@
       "name": "parse_zero_values_build_hierarchy",
       "source_test": "parse_zero_values",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "count": {
+            "0": {}
+          },
+          "disabled": {
+            "no": {}
+          },
+          "distance": {
+            "0.0": {}
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "count = 0\ndistance = 0.0\ndisabled = no"
+      ],
+      "name": "parse_zero_values_build_model",
+      "source_test": "parse_zero_values",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -773,6 +1012,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -781,6 +1021,38 @@
       "name": "parse_zero_values_strict_literal_build_hierarchy",
       "source_test": "parse_zero_values_strict_literal",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "count": {
+            "0": {}
+          },
+          "disabled": {
+            "no": {}
+          },
+          "distance": {
+            "0.0": {}
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "count = 0\ndistance = 0.0\ndisabled = no"
+      ],
+      "name": "parse_zero_values_strict_literal_build_model",
+      "source_test": "parse_zero_values_strict_literal",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -928,6 +1200,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -936,6 +1209,49 @@
       "name": "parse_boolean_variants_build_hierarchy",
       "source_test": "parse_boolean_variants",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flag1": {
+            "yes": {}
+          },
+          "flag2": {
+            "on": {}
+          },
+          "flag3": {
+            "1": {}
+          },
+          "flag4": {
+            "false": {}
+          },
+          "flag5": {
+            "no": {}
+          },
+          "flag6": {
+            "off": {}
+          },
+          "flag7": {
+            "0": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flag1 = yes\nflag2 = on\nflag3 = 1\nflag4 = false\nflag5 = no\nflag6 = off\nflag7 = 0"
+      ],
+      "name": "parse_boolean_variants_build_model",
+      "source_test": "parse_boolean_variants",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1058,6 +1374,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1066,6 +1383,49 @@
       "name": "parse_boolean_variants_strict_literal_build_hierarchy",
       "source_test": "parse_boolean_variants_strict_literal",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flag1": {
+            "yes": {}
+          },
+          "flag2": {
+            "on": {}
+          },
+          "flag3": {
+            "1": {}
+          },
+          "flag4": {
+            "false": {}
+          },
+          "flag5": {
+            "no": {}
+          },
+          "flag6": {
+            "off": {}
+          },
+          "flag7": {
+            "0": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flag1 = yes\nflag2 = on\nflag3 = 1\nflag4 = false\nflag5 = no\nflag6 = off\nflag7 = 0"
+      ],
+      "name": "parse_boolean_variants_strict_literal_build_model",
+      "source_test": "parse_boolean_variants_strict_literal",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1177,6 +1537,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1185,6 +1546,43 @@
       "name": "parse_mixed_types_build_hierarchy",
       "source_test": "parse_mixed_types",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "debug": {
+            "off": {}
+          },
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          },
+          "ssl": {
+            "true": {}
+          },
+          "timeout": {
+            "30.5": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
+      ],
+      "name": "parse_mixed_types_build_model",
+      "source_test": "parse_mixed_types",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1343,6 +1741,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1351,6 +1750,43 @@
       "name": "parse_mixed_types_strict_literal_build_hierarchy",
       "source_test": "parse_mixed_types_strict_literal",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "debug": {
+            "off": {}
+          },
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          },
+          "ssl": {
+            "true": {}
+          },
+          "timeout": {
+            "30.5": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
+      ],
+      "name": "parse_mixed_types_strict_literal_build_model",
+      "source_test": "parse_mixed_types_strict_literal",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1496,6 +1932,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1504,6 +1941,35 @@
       "name": "parse_with_whitespace_build_hierarchy",
       "source_test": "parse_with_whitespace",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flag": {
+            "true": {}
+          },
+          "number": {
+            "42": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "number =   42   \nflag =  true  "
+      ],
+      "name": "parse_with_whitespace_build_model",
+      "source_test": "parse_with_whitespace",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1606,6 +2072,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1614,6 +2081,40 @@
       "name": "parse_with_conservative_options_build_hierarchy",
       "source_test": "parse_with_conservative_options",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "decimal": {
+            "3.14": {}
+          },
+          "flag": {
+            "true": {}
+          },
+          "number": {
+            "42": {}
+          },
+          "text": {
+            "hello": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "number = 42\ndecimal = 3.14\nflag = true\ntext = hello"
+      ],
+      "name": "parse_with_conservative_options_build_model",
+      "source_test": "parse_with_conservative_options",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1699,6 +2200,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1707,6 +2209,31 @@
       "name": "parse_integer_error_build_hierarchy",
       "source_test": "parse_integer_error",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "port": {
+            "not_a_number": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "port = not_a_number"
+      ],
+      "name": "parse_integer_error_build_model",
+      "source_test": "parse_integer_error",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1768,6 +2295,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1776,6 +2304,31 @@
       "name": "parse_float_error_build_hierarchy",
       "source_test": "parse_float_error",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "temperature": {
+            "invalid": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "temperature = invalid"
+      ],
+      "name": "parse_float_error_build_model",
+      "source_test": "parse_float_error",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1837,6 +2390,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1845,6 +2399,31 @@
       "name": "parse_boolean_error_build_hierarchy",
       "source_test": "parse_boolean_error",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "enabled": {
+            "maybe": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "enabled = maybe"
+      ],
+      "name": "parse_boolean_error_build_model",
+      "source_test": "parse_boolean_error",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1909,6 +2488,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1917,6 +2497,29 @@
       "name": "parse_missing_path_error_build_hierarchy",
       "source_test": "parse_missing_path_error",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "existing": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "existing = value"
+      ],
+      "name": "parse_missing_path_error_build_model",
+      "source_test": "parse_missing_path_error",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2267,6 +2870,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2275,6 +2879,39 @@
       "name": "boolean_nested_object_build_hierarchy",
       "source_test": "boolean_nested_object",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "debug": {
+              "true": {}
+            },
+            "experimental": {
+              "yes": {}
+            },
+            "verbose": {
+              "false": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  debug = true\n  verbose = false\n  experimental = yes"
+      ],
+      "name": "boolean_nested_object_build_model",
+      "source_test": "boolean_nested_object",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2440,6 +3077,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2448,6 +3086,36 @@
       "name": "type_mismatch_nested_path_build_hierarchy",
       "source_test": "type_mismatch_nested_path",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "count": {
+              "abc": {}
+            },
+            "name": {
+              "test": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  name = test\n  count = abc"
+      ],
+      "name": "type_mismatch_nested_path_build_model",
+      "source_test": "type_mismatch_nested_path",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2502,6 +3170,994 @@
       "name": "boolean_empty_value_error_get_bool",
       "source_test": "boolean_empty_value_error",
       "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "server",
+            "value": "\n  port = 8080\n  max_connections = 1000"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_parse",
+      "source_test": "nested_get_int",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "max_connections": "1000",
+            "port": "8080"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_build_hierarchy",
+      "source_test": "nested_get_int",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "max_connections": {
+              "1000": {}
+            },
+            "port": {
+              "8080": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_build_model",
+      "source_test": "nested_get_int",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "max_connections"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": 1000
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_get_int",
+      "source_test": "nested_get_int",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "config",
+            "value": "\n  database =\n    pool =\n      min = 5\n      max = 50"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_parse",
+      "source_test": "deeply_nested_get_int",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "database": {
+              "pool": {
+                "max": "50",
+                "min": "5"
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_build_hierarchy",
+      "source_test": "deeply_nested_get_int",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "database": {
+              "pool": {
+                "max": {
+                  "50": {}
+                },
+                "min": {
+                  "5": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_build_model",
+      "source_test": "deeply_nested_get_int",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "config",
+        "database",
+        "pool",
+        "max"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": 50
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_get_int",
+      "source_test": "deeply_nested_get_int",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "metrics",
+            "value": "\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_parse",
+      "source_test": "nested_get_float",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "metrics": {
+            "cpu_threshold": "0.85",
+            "memory_limit": "2.5"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_build_hierarchy",
+      "source_test": "nested_get_float",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "metrics": {
+            "cpu_threshold": {
+              "0.85": {}
+            },
+            "memory_limit": {
+              "2.5": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_build_model",
+      "source_test": "nested_get_float",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "metrics",
+        "memory_limit"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": 2.5
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_float"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_get_float",
+      "source_test": "nested_get_float",
+      "validation": "get_float",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "app",
+            "value": "\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_parse",
+      "source_test": "deeply_nested_get_float",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "app": {
+            "scoring": {
+              "weights": {
+                "freshness": "0.4",
+                "relevance": "0.6"
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_build_hierarchy",
+      "source_test": "deeply_nested_get_float",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "app": {
+            "scoring": {
+              "weights": {
+                "freshness": {
+                  "0.4": {}
+                },
+                "relevance": {
+                  "0.6": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_build_model",
+      "source_test": "deeply_nested_get_float",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "app",
+        "scoring",
+        "weights",
+        "freshness"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": 0.4
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_float"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_get_float",
+      "source_test": "deeply_nested_get_float",
+      "validation": "get_float",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "feature_flags",
+            "value": "\n  dark_mode = true\n  beta_access = false"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_parse",
+      "source_test": "nested_get_bool",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "feature_flags": {
+            "beta_access": "false",
+            "dark_mode": "true"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_build_hierarchy",
+      "source_test": "nested_get_bool",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "feature_flags": {
+            "beta_access": {
+              "false": {}
+            },
+            "dark_mode": {
+              "true": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_build_model",
+      "source_test": "nested_get_bool",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "feature_flags",
+        "beta_access"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient",
+        "path_traversal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "boolean_lenient",
+          "boolean_strict"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": false
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_get_bool",
+      "source_test": "nested_get_bool",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "services",
+            "value": "\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_parse",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "services": {
+            "auth": {
+              "settings": {
+                "allow_anonymous": "false",
+                "require_mfa": "true"
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_build_hierarchy",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "services": {
+            "auth": {
+              "settings": {
+                "allow_anonymous": {
+                  "false": {}
+                },
+                "require_mfa": {
+                  "true": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_build_model",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "services",
+        "auth",
+        "settings",
+        "allow_anonymous"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient",
+        "path_traversal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "boolean_lenient",
+          "boolean_strict"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": false
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_get_bool",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "database",
+            "value": "\n  host = localhost\n  name = mydb"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_parse",
+      "source_test": "nested_get_string_basic",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "host": "localhost",
+            "name": "mydb"
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_build_hierarchy",
+      "source_test": "nested_get_string_basic",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "host": {
+              "localhost": {}
+            },
+            "name": {
+              "mydb": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_build_model",
+      "source_test": "nested_get_string_basic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "database",
+        "name"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": "mydb"
+      },
+      "features": [],
+      "functions": [
+        "get_string"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_get_string",
+      "source_test": "nested_get_string_basic",
+      "validation": "get_string",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "server",
+            "value": "\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_parse",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "debug": "true",
+            "host": "0.0.0.0",
+            "port": "3000",
+            "rate_limit": "1.5"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_build_hierarchy",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "debug": {
+              "true": {}
+            },
+            "host": {
+              "0.0.0.0": {}
+            },
+            "port": {
+              "3000": {}
+            },
+            "rate_limit": {
+              "1.5": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_build_model",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "host"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": "0.0.0.0"
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_string"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_string",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_string",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "port"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": 3000
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_int",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "debug"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient",
+        "path_traversal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "boolean_lenient",
+          "boolean_strict"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": true
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_bool",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "rate_limit"
+      ],
+      "behaviors": [
+        "path_traversal"
+      ],
+      "expected": {
+        "count": 1,
+        "value": 1.5
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_float"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_float",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_float",
       "variants": []
     }
   ]

--- a/crates/sickle/tests/test_data/api_whitespace_behaviors.json
+++ b/crates/sickle/tests/test_data/api_whitespace_behaviors.json
@@ -1,179 +1,20 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
           {
             "key": "key",
-            "value": "\tvalue\twith\ttabs"
+            "value": "value\twith\ttabs"
           }
         ]
       },
       "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ],
-      "name": "tabs_as_content_in_value_parse",
-      "source_test": "tabs_as_content_in_value",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "object": {
-          "key": "\tvalue\twith\ttabs"
-        }
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "build_hierarchy"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ],
-      "name": "tabs_as_content_in_value_build_hierarchy",
-      "source_test": "tabs_as_content_in_value",
-      "validation": "build_hierarchy",
-      "variants": []
-    },
-    {
-      "args": [
-        "key"
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": "\tvalue\twith\ttabs"
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "get_string"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ],
-      "name": "tabs_as_content_in_value_get_string",
-      "source_test": "tabs_as_content_in_value",
-      "validation": "get_string",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key",
-            "value": "\tindented"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key = \tindented"
-      ],
-      "name": "tabs_as_content_leading_tab_parse",
-      "source_test": "tabs_as_content_leading_tab",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "args": [
-        "key"
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": "\tindented"
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "get_string"
-      ],
-      "inputs": [
-        "key = \tindented"
-      ],
-      "name": "tabs_as_content_leading_tab_get_string",
-      "source_test": "tabs_as_content_leading_tab",
-      "validation": "get_string",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key",
-            "value": "value with tabs"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "parse"
@@ -187,24 +28,19 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "object": {
-          "key": "value with tabs"
+          "key": "value\twith\ttabs"
         }
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -216,16 +52,43 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "key": {
+            "value\twith\ttabs": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace",
+        "tab_in_value_preserved"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key = \tvalue\twith\ttabs"
+      ],
+      "name": "tabs_as_whitespace_in_value_build_model",
+      "source_test": "tabs_as_whitespace_in_value",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "key"
       ],
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "value with tabs"
+        "value": "value\twith\ttabs"
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "get_string"
@@ -239,14 +102,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -294,14 +150,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -327,11 +176,12 @@
     },
     {
       "behaviors": [
-        "tabs_as_content"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "conflicts": {
         "behaviors": [
-          "tabs_as_whitespace"
+          "continuation_tab_preserve"
         ]
       },
       "expected": {
@@ -339,46 +189,13 @@
         "entries": [
           {
             "key": "section",
-            "value": "\n \tindented_with_tabs\n \tanother_line"
+            "value": "\n  indented_with_tabs\n  another_line"
           }
         ]
       },
       "features": [
         "whitespace",
-        "multiline"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "section =\n \tindented_with_tabs\n \tanother_line"
-      ],
-      "name": "tabs_as_content_multiline_parse",
-      "source_test": "tabs_as_content_multiline",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "section",
-            "value": "\nindented_with_tabs\nanother_line"
-          }
-        ]
-      },
-      "features": [
-        "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -393,11 +210,12 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "conflicts": {
         "behaviors": [
-          "tabs_as_content"
+          "continuation_tab_preserve"
         ]
       },
       "expected": {
@@ -405,13 +223,13 @@
         "entries": [
           {
             "key": "section",
-            "value": "\nmixed_indent\nanother_line"
+            "value": "\n  mixed_indent\n  another_line"
           }
         ]
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -425,42 +243,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": "key = \tvalue"
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse",
-        "print"
-      ],
-      "inputs": [
-        "key = \tvalue"
-      ],
-      "name": "tabs_canonical_format_as_content_canonical_format",
-      "source_test": "tabs_canonical_format_as_content",
-      "validation": "canonical_format",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "value": "key = value"
@@ -470,7 +253,8 @@
       ],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "key = \tvalue"
@@ -482,13 +266,14 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace",
-        "indent_spaces"
+        "indent_spaces",
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "conflicts": {
         "behaviors": [
-          "indent_tabs",
-          "tabs_as_content"
+          "continuation_tab_preserve",
+          "indent_tabs"
         ]
       },
       "expected": {
@@ -497,11 +282,12 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
@@ -515,10 +301,11 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "key = value with tabs"
+        "value": "key = value\twith\ttabs"
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "parse",
@@ -551,7 +338,8 @@
       ],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "package =\n  = brew\n  = scoop\n  = nix"
@@ -580,13 +368,286 @@
       ],
       "functions": [
         "parse",
-        "print"
+        "print",
+        "canonical_format"
       ],
       "inputs": [
         "app =\n  = item1\n  config =\n    = nested1\n    = nested2\n    deep =\n      = level3a\n      = level3b\n  = item2"
       ],
       "name": "deeply_nested_bare_list_indentation_canonical_format",
       "source_test": "deeply_nested_bare_list_indentation",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "database =\n  host = localhost\n  port = 5432"
+      },
+      "features": [],
+      "functions": [
+        "print"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  port = 5432"
+      ],
+      "name": "print_nested_indent_spaces_print",
+      "source_test": "print_nested_indent_spaces",
+      "validation": "print",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
+      },
+      "features": [],
+      "functions": [
+        "print"
+      ],
+      "inputs": [
+        "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
+      ],
+      "name": "print_deeply_nested_indent_spaces_print",
+      "source_test": "print_deeply_nested_indent_spaces",
+      "validation": "print",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "database =\n\thost = localhost\n\tport = 5432"
+      },
+      "features": [],
+      "functions": [
+        "print"
+      ],
+      "inputs": [
+        "database =\n\thost = localhost\n\tport = 5432"
+      ],
+      "name": "print_nested_indent_tabs_print",
+      "source_test": "print_nested_indent_tabs",
+      "validation": "print",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "server =\n\tdatabase =\n\t\thost = localhost\n\t\tport = 5432\n\tcache =\n\t\tenabled = true"
+      },
+      "features": [],
+      "functions": [
+        "print"
+      ],
+      "inputs": [
+        "server =\n\tdatabase =\n\t\thost = localhost\n\t\tport = 5432\n\tcache =\n\t\tenabled = true"
+      ],
+      "name": "print_deeply_nested_indent_tabs_print",
+      "source_test": "print_deeply_nested_indent_tabs",
+      "validation": "print",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "name = Alice\nconfig =\n\tdebug = true\n\ttimeout = 30\nversion = 1.0"
+      },
+      "features": [],
+      "functions": [
+        "print"
+      ],
+      "inputs": [
+        "name = Alice\nconfig =\n\tdebug = true\n\ttimeout = 30\nversion = 1.0"
+      ],
+      "name": "print_mixed_flat_and_nested_indent_tabs_print",
+      "source_test": "print_mixed_flat_and_nested_indent_tabs",
+      "validation": "print",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "a =\n\tfirst =\nm =\n\tmiddle =\nz =\n\tlast =\n"
+      },
+      "features": [],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "z = last\na = first\nm = middle"
+      ],
+      "name": "canonical_format_deterministic_indent_tabs_canonical_format",
+      "source_test": "canonical_format_deterministic_indent_tabs",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "key1 =\n\tvalue1 =\nkey2 =\n\tvalue2 =\nkey3 =\n\tvalue3 =\n"
+      },
+      "features": [],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "key1=value1\nkey2  =  value2\nkey3\t=\tvalue3"
+      ],
+      "name": "canonical_format_consistent_spacing_indent_tabs_canonical_format",
+      "source_test": "canonical_format_consistent_spacing_indent_tabs",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs",
+        "multiline_values",
+        "continuation_tab_to_space"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "continuation_tab_preserve",
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "section =\n\tindented\n\tanother"
+      },
+      "features": [
+        "whitespace",
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "section =\n\t\tindented\n\t\tanother"
+      ],
+      "name": "tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format",
+      "source_test": "tabs_as_whitespace_multiline_canonical_indent_tabs",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "package =\n\t= brew\n\t= scoop\n\t= nix"
+      },
+      "features": [
+        "empty_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "package =\n\t= brew\n\t= scoop\n\t= nix"
+      ],
+      "name": "nested_bare_list_indentation_tabs_canonical_format",
+      "source_test": "nested_bare_list_indentation_tabs",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_tabs"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_spaces"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "app =\n\t= item1\n\t= item2\n\tconfig =\n\t\t= nested1\n\t\t= nested2\n\t\tdeep =\n\t\t\t= level3a\n\t\t\t= level3b"
+      },
+      "features": [
+        "empty_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "app =\n\t= item1\n\tconfig =\n\t\t= nested1\n\t\t= nested2\n\t\tdeep =\n\t\t\t= level3a\n\t\t\t= level3b\n\t= item2"
+      ],
+      "name": "deeply_nested_bare_list_indentation_tabs_canonical_format",
+      "source_test": "deeply_nested_bare_list_indentation_tabs",
       "validation": "canonical_format",
       "variants": []
     },
@@ -646,6 +707,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -654,6 +716,41 @@
       "name": "crlf_normalize_to_lf_basic_build_hierarchy",
       "source_test": "crlf_normalize_to_lf_basic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "key1": {
+            "value1": {}
+          },
+          "key2": {
+            "value2": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
+      "name": "crlf_normalize_to_lf_basic_build_model",
+      "source_test": "crlf_normalize_to_lf_basic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -712,6 +809,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -724,7 +822,43 @@
     },
     {
       "behaviors": [
-        "crlf_normalize_to_lf"
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "key1": {
+            "value1\r": {}
+          },
+          "key2": {
+            "value2\r": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
+      "name": "crlf_preserve_literal_basic_build_model",
+      "source_test": "crlf_preserve_literal_basic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -742,7 +876,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -757,7 +891,8 @@
     },
     {
       "behaviors": [
-        "crlf_preserve_literal"
+        "crlf_preserve_literal",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -775,7 +910,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -882,6 +1017,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -890,6 +1026,43 @@
       "name": "crlf_nested_structure_build_hierarchy",
       "source_test": "crlf_nested_structure",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "8080": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ],
+      "name": "crlf_nested_structure_build_model",
+      "source_test": "crlf_nested_structure",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -946,6 +1119,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -954,6 +1128,43 @@
       "name": "crlf_preserve_nested_structure_build_hierarchy",
       "source_test": "crlf_preserve_nested_structure",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "host": {
+              "localhost\r": {}
+            },
+            "port": {
+              "8080": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ],
+      "name": "crlf_preserve_nested_structure_build_model",
+      "source_test": "crlf_preserve_nested_structure",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -990,7 +1201,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -1005,6 +1223,11 @@
         "/= this is a comment\r\n"
       ],
       "name": "crlf_normalize_comment_only_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "crlf_normalize_comment_only",
       "validation": "filter",
       "variants": []
@@ -1043,7 +1266,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -1058,6 +1288,11 @@
         "/= this is a comment\r\n"
       ],
       "name": "crlf_preserve_comment_only_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "crlf_preserve_comment_only",
       "validation": "filter",
       "variants": []
@@ -1108,7 +1343,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [
@@ -1133,6 +1375,11 @@
         "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
       ],
       "name": "crlf_normalize_comments_and_values_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "crlf_normalize_comments_and_values",
       "validation": "filter",
       "variants": []
@@ -1149,6 +1396,10 @@
       "expected": {
         "count": 1,
         "object": {
+          "/": [
+            "Server config",
+            "Port setting"
+          ],
           "host": "localhost",
           "port": "8080"
         }
@@ -1158,6 +1409,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1166,6 +1418,46 @@
       "name": "crlf_normalize_comments_and_values_build_hierarchy",
       "source_test": "crlf_normalize_comments_and_values",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "Port setting": {},
+            "Server config": {}
+          },
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          }
+        }
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_normalize_comments_and_values_build_model",
+      "source_test": "crlf_normalize_comments_and_values",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1214,7 +1506,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [
@@ -1239,6 +1538,11 @@
         "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
       ],
       "name": "crlf_preserve_comments_and_values_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "crlf_preserve_comments_and_values",
       "validation": "filter",
       "variants": []
@@ -1255,6 +1559,10 @@
       "expected": {
         "count": 1,
         "object": {
+          "/": [
+            "Server config\r",
+            "Port setting\r"
+          ],
           "host": "localhost\r",
           "port": "8080\r"
         }
@@ -1264,6 +1572,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1272,6 +1581,46 @@
       "name": "crlf_preserve_comments_and_values_build_hierarchy",
       "source_test": "crlf_preserve_comments_and_values",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "Port setting\r": {},
+            "Server config\r": {}
+          },
+          "host": {
+            "localhost\r": {}
+          },
+          "port": {
+            "8080\r": {}
+          }
+        }
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_preserve_comments_and_values_build_model",
+      "source_test": "crlf_preserve_comments_and_values",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1316,7 +1665,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -1331,6 +1687,11 @@
         "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
       ],
       "name": "crlf_normalize_multiple_comments_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "crlf_normalize_multiple_comments",
       "validation": "filter",
       "variants": []
@@ -1377,7 +1738,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -1392,19 +1760,22 @@
         "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
       ],
       "name": "crlf_preserve_multiple_comments_filter",
+      "predicate": {
+        "field": "key",
+        "op": "!=",
+        "value": "/"
+      },
       "source_test": "crlf_preserve_multiple_comments",
       "validation": "filter",
       "variants": []
     },
     {
       "behaviors": [
-        "tabs_as_whitespace",
         "crlf_normalize_to_lf"
       ],
       "conflicts": {
         "behaviors": [
-          "crlf_preserve_literal",
-          "tabs_as_content"
+          "crlf_preserve_literal"
         ]
       },
       "expected": {
@@ -1412,12 +1783,13 @@
         "entries": [
           {
             "key": "key",
-            "value": "value with tabs"
+            "value": "value\twith\ttabs"
           }
         ]
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "parse"
@@ -1432,40 +1804,124 @@
     },
     {
       "behaviors": [
-        "tabs_as_content",
-        "crlf_normalize_to_lf"
+        "indent_spaces",
+        "toplevel_indent_strip"
       ],
       "conflicts": {
         "behaviors": [
-          "crlf_preserve_literal",
-          "tabs_as_whitespace"
+          "indent_tabs",
+          "toplevel_indent_preserve"
         ]
       },
       "expected": {
-        "count": 2,
-        "entries": [
-          {
-            "key": "key1",
-            "value": "\tvalue1"
-          },
-          {
-            "key": "key2",
-            "value": "\tvalue2"
-          }
-        ]
+        "count": 1,
+        "value": "key = value\nnested =\n  child = inner"
       },
       "features": [
         "whitespace"
       ],
       "functions": [
-        "parse"
+        "parse",
+        "print",
+        "canonical_format"
       ],
       "inputs": [
-        "key1 = \tvalue1\r\nkey2 = \tvalue2\r\n"
+        "  key = value\n  nested =\n    child = inner"
       ],
-      "name": "behavior_combo_content_tabs_crlf_parse",
-      "source_test": "behavior_combo_content_tabs_crlf",
-      "validation": "parse",
+      "name": "toplevel_indent_strip_canonical_canonical_format",
+      "source_test": "toplevel_indent_strip_canonical",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_preserve"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs",
+          "toplevel_indent_strip"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "  key = value\n  nested =\n    child = inner"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "  key = value\n  nested =\n    child = inner"
+      ],
+      "name": "toplevel_indent_preserve_canonical_canonical_format",
+      "source_test": "toplevel_indent_preserve_canonical",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_strip"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs",
+          "toplevel_indent_preserve"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "key = value"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "  key = value"
+      ],
+      "name": "toplevel_indent_strip_round_trip_round_trip",
+      "source_test": "toplevel_indent_strip_round_trip",
+      "validation": "round_trip",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_preserve"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs",
+          "toplevel_indent_strip"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "  key = value"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "  key = value"
+      ],
+      "name": "toplevel_indent_preserve_round_trip_round_trip",
+      "source_test": "toplevel_indent_preserve_round_trip",
+      "validation": "round_trip",
       "variants": []
     }
   ]

--- a/crates/sickle/tests/test_data/property_algebraic.json
+++ b/crates/sickle/tests/test_data/property_algebraic.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -9,7 +9,8 @@
       },
       "features": [],
       "functions": [
-        "compose_associative"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "a = 1",
@@ -29,7 +30,8 @@
       },
       "features": [],
       "functions": [
-        "compose_associative"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "config =\n  host = localhost",
@@ -51,7 +53,8 @@
         "empty_keys"
       ],
       "functions": [
-        "compose_associative"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "= item1",
@@ -71,7 +74,8 @@
       },
       "features": [],
       "functions": [
-        "identity_left"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "",
@@ -90,7 +94,8 @@
       },
       "features": [],
       "functions": [
-        "identity_right"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "key = value\nnested =\n  sub = val",
@@ -109,7 +114,8 @@
       },
       "features": [],
       "functions": [
-        "identity_left"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "",
@@ -128,7 +134,8 @@
       },
       "features": [],
       "functions": [
-        "identity_right"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "config =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    redis = true",
@@ -149,7 +156,8 @@
         "empty_keys"
       ],
       "functions": [
-        "identity_left"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "",
@@ -170,7 +178,8 @@
         "empty_keys"
       ],
       "functions": [
-        "identity_right"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "= item1\n= item2\n= item3",
@@ -272,7 +281,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "config = \n  host = localhost\n  port = 8080\n  db =\n    name = mydb\n    user = admin"
+        "value": "config =\n  host = localhost\n  port = 8080\n  db =\n    name = mydb\n    user = admin"
       },
       "features": [],
       "functions": [
@@ -346,7 +355,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": " = item1\n = item2\nconfig = \n  nested =\n    deep = value\n  list =\n    = a\n    = b\n    = c\nfinal = end"
+        "value": "= item1\n= item2\nconfig =\n  nested =\n    deep = value\n  list =\n    = a\n    = b\n    = c\nfinal = end"
       },
       "features": [
         "empty_keys"

--- a/crates/sickle/tests/test_data/property_round_trip.json
+++ b/crates/sickle/tests/test_data/property_round_trip.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v0.6.0/schemas/generated-format.json",
+  "$schema": "https://raw.githubusercontent.com/CatConfLang/ccl-test-data/v1.1.0/schemas/generated-format.json",
   "tests": [
     {
       "behaviors": [],
@@ -32,7 +32,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "key = value\nnested = \n  sub = val"
+        "value": "key = value\nnested =\n  sub = val"
       },
       "features": [],
       "functions": [
@@ -66,14 +66,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "toplevel_indent_strip"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_preserve"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -84,7 +77,8 @@
         ]
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "toplevel_indent_strip"
       ],
       "functions": [
         "parse"
@@ -106,7 +100,8 @@
         "value": true
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "toplevel_indent_strip"
       ],
       "functions": [
         "parse",
@@ -121,63 +116,6 @@
       "variants": [
         "reference_compliant"
       ]
-    },
-    {
-      "behaviors": [
-        "toplevel_indent_preserve"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_strip"
-        ]
-      },
-      "expected": {
-        "count": 2,
-        "entries": [
-          {
-            "key": "key",
-            "value": "value"
-          },
-          {
-            "key": "nested",
-            "value": "\n    sub  =  val"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "  key  =  value  \n  nested  = \n    sub  =  val  "
-      ],
-      "name": "round_trip_whitespace_normalization_toplevel_indent_preserve_parse",
-      "source_test": "round_trip_whitespace_normalization_toplevel_indent_preserve",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [],
-      "expected": {
-        "count": 1,
-        "value": true
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse",
-        "print"
-      ],
-      "inputs": [
-        "  key  =  value  \n  nested  = \n    sub  =  val  "
-      ],
-      "name": "round_trip_whitespace_normalization_toplevel_indent_preserve_round_trip",
-      "source_test": "round_trip_whitespace_normalization_toplevel_indent_preserve",
-      "validation": "round_trip",
-      "variants": []
     },
     {
       "behaviors": [],
@@ -280,7 +218,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "config = \n  host = localhost\n  port = 8080\n  db =\n    name = mydb\n    user = admin"
+        "value": "config =\n  host = localhost\n  port = 8080\n  db =\n    name = mydb\n    user = admin"
       },
       "features": [],
       "functions": [
@@ -314,7 +252,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -325,7 +265,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -342,10 +282,10 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "script = \n  #!/bin/bash\n  echo hello\n  exit 0"
+        "value": "script =\n  #!/bin/bash\n  echo hello\n  exit 0"
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"
@@ -359,13 +299,15 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "value": true
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",
@@ -424,7 +366,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "name = Alice\n= first item\nconfig = \n  port = 3000\n= second item\nfinal = value"
+        "value": "name = Alice\n= first item\nconfig =\n  port = 3000\n= second item\nfinal = value"
       },
       "features": [
         "empty_keys"
@@ -490,7 +432,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "app = \n  = item1\n  config =\n    = nested_item\n    db =\n      host = localhost\n      = db_item\n  = item2"
+        "value": "app =\n  = item1\n  config =\n    = nested_item\n    db =\n      host = localhost\n      = db_item\n  = item2"
       },
       "features": [
         "empty_keys"
@@ -556,7 +498,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "level1 = \n  level2 =\n    level3 =\n      level4 =\n        deep = value\n        = deep_item"
+        "value": "level1 =\n  level2 =\n    level3 =\n      level4 =\n        deep = value\n        = deep_item"
       },
       "features": [
         "empty_keys"
@@ -594,7 +536,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -610,7 +554,7 @@
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -627,11 +571,11 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "empty_section = \nother = value"
+        "value": "empty_section =\nother = value"
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"
@@ -645,14 +589,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "value": true
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",


### PR DESCRIPTION
## Summary

- Add `nom`-backed Pacman delimiter parsing helpers for Sickle while preserving the public API.
- Refresh generated CCL JSON conformance fixtures from upstream and update the data-driven runner for filter predicates.
- Align parser/model/printer behavior with upstream CCL expectations, including multiline keys, delimiter whitespace, duplicate-key lists, empty scalar handling, and canonical print spacing.
- Make `nom` a required Sickle dependency while keeping parser APIs behind the existing `parse` feature.

## Validation

- `cargo test -p sickle --features full,unstable`
- `cargo check -p sickle`
- `cargo test -p santa-data`
- `cargo test -p santa`
- `changie batch auto --dry-run --project sickle`
- `just format --check`
- `just sickle-capabilities`
- `git diff --check`
