### PR TITLE
feat(sickle): comment-preserving document edit API

### DIFF
--- a/.changes/unreleased/sickle-feat-document-api.yaml
+++ b/.changes/unreleased/sickle-feat-document-api.yaml
@@ -1,0 +1,3 @@
+project: sickle
+kind: Added
+body: Add comment/format-preserving document API (`load_document`, `Document::deserialize`, `Document::reserialize`) behind the `document` feature, so read-modify-write cycles keep hand-written comments, blank lines, key order, and formatting where data is unchanged

--- a/.changes/unreleased/sickle-fix-blank-line-collision.yaml
+++ b/.changes/unreleased/sickle-fix-blank-line-collision.yaml
@@ -1,0 +1,3 @@
+project: sickle
+kind: Fixed
+body: Stop `CclObject::add_blank_line()` from overwriting bare list (`= item`) entries by using a collision-free sentinel key, and ignore comment/blank trivia keys when deserializing maps so comments inside a map no longer break deserialization

--- a/.changes/unreleased/sickle-fix-comment-roundtrip.yaml
+++ b/.changes/unreleased/sickle-fix-comment-roundtrip.yaml
@@ -1,0 +1,3 @@
+project: sickle
+kind: Fixed
+body: Round-trip top-level comments faithfully as `/= text` instead of reformatting them to `/ = text` in both the `print` and `CclPrinter` pipelines

--- a/crates/sickle/Cargo.toml
+++ b/crates/sickle/Cargo.toml
@@ -36,6 +36,11 @@ serde-serialize = ["printer", "dep:serde", "dep:serde_derive"]
 # Both serde serialization and deserialization
 serde = ["serde-deserialize", "serde-serialize"]
 
+# Comment/format-preserving document edit API (load_document/deserialize/reserialize).
+# Requires both serde directions: deserialize for the typed view, serialize for the
+# canonical form that is merged back into the source document.
+document = ["serde"]
+
 # String interning for memory efficiency with large configs
 intern = ["dep:string-interner"]
 
@@ -45,8 +50,7 @@ intern = ["dep:string-interner"]
 reference_compliant = []
 
 # All features enabled
-full = ["serde", "printer", "intern"]
-
+full = ["serde", "printer", "intern", "document"]
 # Unstable APIs - exposes internal functions for testing/experimentation
 # These APIs may change without notice
 unstable = []

--- a/crates/sickle/src/de.rs
+++ b/crates/sickle/src/de.rs
@@ -555,15 +555,23 @@ impl<'de, 'a> MapAccess<'de> for MapDeserializer<'a> {
     where
         K: DeserializeSeed<'de>,
     {
-        match self.iter.next() {
-            Some((key, vec)) => {
-                // Take the first value from the Vec (serde expects single values per key)
-                self.value = vec.first();
-                // Store the full Vec for potential list deserialization
-                self.full_vec = Some(vec);
-                seed.deserialize(key.as_str().into_deserializer()).map(Some)
+        // Skip CCL trivia keys: comments are parsed as key `/` and explicit blank
+        // lines use the NUL sentinel. For struct deserialization these are unknown
+        // fields that serde would ignore anyway; for map deserialization every
+        // entry is significant, so they must be skipped here or a comment inside a
+        // map (e.g. a `BTreeMap` of named sources) would fail to deserialize.
+        loop {
+            match self.iter.next() {
+                Some((key, _)) if key == "/" || key == crate::model::BLANK_LINE_KEY => continue,
+                Some((key, vec)) => {
+                    // Take the first value from the Vec (serde expects single values per key)
+                    self.value = vec.first();
+                    // Store the full Vec for potential list deserialization
+                    self.full_vec = Some(vec);
+                    return seed.deserialize(key.as_str().into_deserializer()).map(Some);
+                }
+                None => return Ok(None),
             }
-            None => Ok(None),
         }
     }
 

--- a/crates/sickle/src/document.rs
+++ b/crates/sickle/src/document.rs
@@ -1,0 +1,400 @@
+//! Comment- and format-preserving document editing for CCL (issue #206).
+//!
+//! The serde round-trip (`from_str` -> edit struct -> `to_string`) is lossy: it
+//! drops every comment, blank line, and formatting nuance that the typed struct
+//! does not model. This module adds a [`Document`] type — analogous to
+//! `toml_edit`'s `DocumentMut` — that retains the source trivia so a
+//! read-modify-write cycle preserves the user's hand-written comments, blank
+//! lines, key order, and spacing wherever the data is unchanged:
+//!
+//! ```
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Config { name: String, version: String }
+//!
+//! let text = "/= my config\nname = app\nversion = 1.0.0\n";
+//! let doc = sickle::load_document(text).unwrap();
+//! let mut cfg: Config = doc.deserialize().unwrap();
+//! cfg.version = "2.0.0".to_string();
+//! let out = doc.reserialize(&cfg).unwrap();
+//! assert!(out.contains("/= my config"));   // comment preserved
+//! assert!(out.contains("version = 2.0.0")); // value updated
+//! ```
+//!
+//! ## How it works
+//!
+//! CCL parsing is recursive ("pacman"): a block is a list of `key = value`
+//! entries, and each value is itself a block parsed the same way. [`Document`]
+//! mirrors that structure as a recursive AST in which every node keeps its
+//! **verbatim source lines**, plus blank lines and comments as first-class
+//! items. Unchanged regions are emitted byte-for-byte from their original lines;
+//! only edited entries are re-rendered from the freshly serialized struct.
+//!
+//! [`reserialize`](Document::reserialize) serializes the edited value to
+//! canonical CCL, parses it into the same AST shape, and merges it into the base
+//! document: matching keys keep their original formatting (recursing into nested
+//! blocks), changed scalars are replaced, removed keys drop along with the
+//! comments attached directly above them, and newly added keys are appended.
+
+use crate::error::Result;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::collections::VecDeque;
+
+use indexmap::IndexMap;
+
+/// A CCL document that preserves comments, blank lines, key order, and
+/// formatting across a read-modify-write cycle.
+///
+/// Construct one with [`load_document`], read a typed view with
+/// [`deserialize`](Document::deserialize), and write the edited value back with
+/// [`reserialize`](Document::reserialize).
+#[derive(Debug, Clone)]
+pub struct Document {
+    /// The original source text, used for the typed (`deserialize`) view.
+    source: String,
+    /// Whether the source ended with a trailing newline.
+    trailing_newline: bool,
+    /// The top-level block of the document.
+    items: Vec<Item>,
+}
+
+/// One line-level item within a block.
+#[derive(Debug, Clone)]
+enum Item {
+    /// A blank line.
+    Blank,
+    /// A comment line, stored verbatim (including indentation), e.g. `"  /= note"`.
+    Comment(String),
+    /// A `key = value` entry (possibly with a nested block as its value).
+    Entry(EntryNode),
+}
+
+/// A single CCL entry and its (possibly nested) value, kept as verbatim lines.
+#[derive(Debug, Clone)]
+struct EntryNode {
+    /// The entry key (text before the first `=`, trimmed). Empty for bare list
+    /// items (`= item`).
+    key: String,
+    /// The verbatim header line, e.g. `"  github ="` or `"name = app"`.
+    header: String,
+    /// Verbatim continuation lines (the indented child block / multiline value).
+    child_lines: Vec<String>,
+    /// Parsed children, present only when the value is structurally a CCL block
+    /// (contains at least one `=` entry). `None` for scalar / multiline-string
+    /// values.
+    children: Option<Vec<Item>>,
+}
+
+/// Load CCL text into a [`Document`], retaining comments, blank lines, and order.
+///
+/// Requires the `document` feature.
+pub fn load_document(input: &str) -> Result<Document> {
+    let trailing_newline = input.ends_with('\n');
+    // Work on logical lines without trailing '\n'. `lines()` also strips '\r',
+    // which we keep out of the comparison; CRLF inputs round-trip via LF.
+    let lines: Vec<&str> = input.lines().collect();
+    let level = base_indent(&lines).unwrap_or(0);
+    let items = parse_block(&lines, level);
+    Ok(Document {
+        source: input.to_string(),
+        trailing_newline,
+        items,
+    })
+}
+
+impl Document {
+    /// Deserialize the document into a typed value.
+    ///
+    /// Comments and blank lines are ignored, so this is equivalent to
+    /// [`from_str`](crate::from_str) on the original source.
+    pub fn deserialize<T: DeserializeOwned>(&self) -> Result<T> {
+        crate::from_str(&self.source)
+    }
+
+    /// Serialize `value` back to CCL text, preserving the document's comments,
+    /// blank lines, and formatting wherever the data is unchanged.
+    ///
+    /// Entries whose values are unchanged are emitted byte-for-byte from the
+    /// original source. Changed scalar values are replaced, nested blocks are
+    /// merged recursively, removed keys are dropped together with the comments
+    /// attached directly above them, and newly added keys are appended.
+    pub fn reserialize<T: Serialize>(&self, value: &T) -> Result<String> {
+        let new_text = crate::to_string(value)?;
+        let new_lines: Vec<&str> = new_text.lines().collect();
+        let new_level = base_indent(&new_lines).unwrap_or(0);
+        let new_items = parse_block(&new_lines, new_level);
+
+        let merged = merge_block(&self.items, &new_items);
+        let rendered = render_items(&merged);
+        let mut out = rendered.join("\n");
+        if self.trailing_newline && !out.is_empty() {
+            out.push('\n');
+        }
+        Ok(out)
+    }
+
+    /// Render the document back to text without applying any edits.
+    ///
+    /// For an unmodified document this reproduces the original source. (Also
+    /// available via [`Display`](std::fmt::Display)/`to_string`.)
+    pub fn render(&self) -> String {
+        let mut out = render_items(&self.items).join("\n");
+        if self.trailing_newline && !out.is_empty() {
+            out.push('\n');
+        }
+        out
+    }
+}
+
+// ============================================================================
+// Parsing: recursive, line-based, trivia-preserving
+// ============================================================================
+
+/// Number of leading whitespace characters on a line.
+fn indent_of(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// The indentation level of the first non-blank line, if any.
+fn base_indent(lines: &[&str]) -> Option<usize> {
+    lines
+        .iter()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| indent_of(l))
+}
+
+/// Whether the next non-blank line at or after `start` is indented deeper than
+/// `level` (i.e. still part of the current entry's value).
+fn next_nonblank_deeper(lines: &[&str], start: usize, level: usize) -> bool {
+    lines[start..]
+        .iter()
+        .find(|l| !l.trim().is_empty())
+        .is_some_and(|l| indent_of(l) > level)
+}
+
+/// The key portion of an entry header (text before the first `=`, trimmed).
+fn split_key(header_trimmed: &str) -> String {
+    match header_trimmed.find('=') {
+        Some(p) => header_trimmed[..p].trim().to_string(),
+        None => header_trimmed.trim().to_string(),
+    }
+}
+
+/// The value portion of an entry header (text after the first `=`, trimmed).
+fn inline_value(header: &str) -> &str {
+    match header.find('=') {
+        Some(p) => header[p + 1..].trim(),
+        None => "",
+    }
+}
+
+/// Parse a block of lines at the given indentation level into ordered items.
+fn parse_block(lines: &[&str], level: usize) -> Vec<Item> {
+    let mut items = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim();
+
+        if trimmed.is_empty() {
+            items.push(Item::Blank);
+            i += 1;
+            continue;
+        }
+
+        if trimmed.starts_with("/=") {
+            items.push(Item::Comment(line.to_string()));
+            i += 1;
+            continue;
+        }
+
+        // Entry header on this line; collect its continuation (child) lines:
+        // every following line indented deeper than `level`, including interior
+        // blank lines that still precede deeper content.
+        let mut j = i + 1;
+        while j < lines.len() {
+            let l2 = lines[j];
+            if l2.trim().is_empty() {
+                if next_nonblank_deeper(lines, j + 1, level) {
+                    j += 1;
+                    continue;
+                }
+                break;
+            }
+            if indent_of(l2) > level {
+                j += 1;
+            } else {
+                break;
+            }
+        }
+
+        let child_lines: Vec<String> = lines[i + 1..j].iter().map(|s| s.to_string()).collect();
+        let children = parse_children(&child_lines);
+        items.push(Item::Entry(EntryNode {
+            key: split_key(trimmed),
+            header: line.to_string(),
+            child_lines,
+            children,
+        }));
+        i = j;
+    }
+    items
+}
+
+/// Parse child lines into a nested block, returning `Some` only when the value
+/// is structurally a CCL block (has at least one `=` entry). Scalar and
+/// multiline-string values return `None`.
+fn parse_children(child_lines: &[String]) -> Option<Vec<Item>> {
+    let refs: Vec<&str> = child_lines.iter().map(String::as_str).collect();
+    let level = base_indent(&refs)?;
+    let items = parse_block(&refs, level);
+    let is_block = items
+        .iter()
+        .any(|it| matches!(it, Item::Entry(e) if e.header.contains('=')));
+    is_block.then_some(items)
+}
+
+// ============================================================================
+// Merging: splice the freshly serialized value into the base document
+// ============================================================================
+
+/// Merge a freshly serialized block (`new`, no trivia) into the base block
+/// (`base`, with comments/blanks), preserving trivia and original formatting.
+fn merge_block(base: &[Item], new: &[Item]) -> Vec<Item> {
+    // Occurrence queues so duplicate keys (Vec fields, bare list items) match
+    // positionally instead of collapsing.
+    let mut queues: IndexMap<String, VecDeque<usize>> = IndexMap::new();
+    for (idx, it) in new.iter().enumerate() {
+        if let Item::Entry(e) = it {
+            queues.entry(e.key.clone()).or_default().push_back(idx);
+        }
+    }
+    let mut consumed = vec![false; new.len()];
+
+    let mut result: Vec<Item> = Vec::new();
+    // Comments/blanks seen since the last emitted entry, pending attachment.
+    let mut trivia: Vec<Item> = Vec::new();
+
+    for item in base {
+        match item {
+            Item::Blank | Item::Comment(_) => trivia.push(item.clone()),
+            Item::Entry(b) => {
+                let matched = queues.get_mut(&b.key).and_then(VecDeque::pop_front);
+                match matched {
+                    Some(ni) => {
+                        consumed[ni] = true;
+                        result.append(&mut trivia);
+                        let n = match &new[ni] {
+                            Item::Entry(e) => e,
+                            _ => unreachable!("queues only index entries"),
+                        };
+                        result.push(Item::Entry(merge_entry(b, n)));
+                    }
+                    None => {
+                        // Key removed by the edit: keep standalone trivia but drop
+                        // the comments attached directly above this entry.
+                        let mut kept = trivia_on_removal(&trivia);
+                        result.append(&mut kept);
+                        trivia.clear();
+                    }
+                }
+            }
+        }
+    }
+    // Trailing trivia (after the last entry) is always preserved.
+    result.append(&mut trivia);
+
+    // Append entries that exist only in the new value, in serializer order.
+    // Skip empty-valued leftovers (empty inline value and no nested block): these
+    // come from empty collections / `None`-like fields and would add spurious
+    // `key =` lines that were never in the source.
+    for (idx, it) in new.iter().enumerate() {
+        if !consumed[idx] {
+            if let Item::Entry(e) = it {
+                if inline_value(&e.header).is_empty() && e.child_lines.is_empty() {
+                    continue;
+                }
+                result.push(it.clone());
+            }
+        }
+    }
+
+    result
+}
+
+/// Merge a base entry with its matching new entry.
+fn merge_entry(b: &EntryNode, n: &EntryNode) -> EntryNode {
+    let b_block = b.children.is_some() && b.header.contains('=');
+    let n_block = n.children.is_some();
+
+    if b_block && n_block {
+        // Same key, both nested: keep the base header's formatting and merge the
+        // child blocks recursively.
+        let merged = merge_block(b.children.as_ref().unwrap(), n.children.as_ref().unwrap());
+        let child_lines = render_items(&merged);
+        return EntryNode {
+            key: b.key.clone(),
+            header: b.header.clone(),
+            child_lines,
+            children: Some(merged),
+        };
+    }
+
+    // Scalar value (or a structural change between scalar and block): keep the
+    // base verbatim when the value is unchanged, otherwise take the new canonical
+    // rendering.
+    if entries_value_equal(b, n) {
+        b.clone()
+    } else {
+        n.clone()
+    }
+}
+
+/// Whether two entries encode the same value (ignoring formatting differences
+/// such as spacing around `=`).
+fn entries_value_equal(b: &EntryNode, n: &EntryNode) -> bool {
+    inline_value(&b.header) == inline_value(&n.header)
+        && b.child_lines.len() == n.child_lines.len()
+        && b.child_lines
+            .iter()
+            .zip(&n.child_lines)
+            .all(|(x, y)| x.trim_end() == y.trim_end())
+}
+
+/// Resolve pending trivia when the following entry is removed: keep everything
+/// up to and including the last blank line (standalone comment blocks and
+/// separators), and drop the comments attached directly above the removed entry.
+fn trivia_on_removal(trivia: &[Item]) -> Vec<Item> {
+    match trivia.iter().rposition(|t| matches!(t, Item::Blank)) {
+        Some(idx) => trivia[..=idx].to_vec(),
+        None => Vec::new(),
+    }
+}
+
+// ============================================================================
+// Rendering
+// ============================================================================
+
+/// Render items back into verbatim source lines.
+fn render_items(items: &[Item]) -> Vec<String> {
+    let mut out = Vec::new();
+    for it in items {
+        match it {
+            Item::Blank => out.push(String::new()),
+            Item::Comment(line) => out.push(line.clone()),
+            Item::Entry(e) => {
+                out.push(e.header.clone());
+                out.extend(e.child_lines.iter().cloned());
+            }
+        }
+    }
+    out
+}
+
+impl std::fmt::Display for Document {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.render())
+    }
+}

--- a/crates/sickle/src/lib.rs
+++ b/crates/sickle/src/lib.rs
@@ -66,6 +66,7 @@
 //! - `serde-deserialize`: Serde deserialization (`from_str`) - includes `hierarchy`
 //! - `serde-serialize`: Serde serialization (`to_string`) - includes `printer`
 //! - `serde`: Both serialization and deserialization
+//! - `document`: Comment/format-preserving edit API ([`load_document`], [`Document`])
 //! - `intern`: String interning for memory efficiency with large configs
 //! - `full`: Enable all features
 //!
@@ -91,6 +92,12 @@ pub mod de;
 
 #[cfg(feature = "serde-serialize")]
 pub mod ser;
+
+#[cfg(feature = "document")]
+pub mod document;
+
+#[cfg(feature = "document")]
+pub use document::{load_document, Document};
 
 pub use error::{Error, Result};
 pub use model::{BoolOptions, CclObject, Entry, ListOptions};

--- a/crates/sickle/src/model.rs
+++ b/crates/sickle/src/model.rs
@@ -11,6 +11,13 @@ use serde::{Deserialize, Serialize};
 // Type Aliases - prevent confusion between single-value and multi-value maps
 // ============================================================================
 
+/// Sentinel key used to represent an explicit blank line in a [`CclObject`].
+///
+/// Real CCL keys can never contain a NUL byte, so this marker is collision-free
+/// with parsed content (notably the empty key `""` used by bare list items).
+/// The printer renders an entry with this key as a blank line.
+pub(crate) const BLANK_LINE_KEY: &str = "\u{0}blank";
+
 /// The internal storage type for CclObject - maps keys to a Vec of values.
 /// Each key can have multiple values, preserving duplicate key semantics.
 pub(crate) type CclMap = IndexMap<String, Vec<CclObject>>;
@@ -332,9 +339,16 @@ impl CclObject {
     /// // When printed, adds visual separation
     /// ```
     pub fn add_blank_line(&mut self) {
-        // Use a unique blank line marker that won't conflict with actual empty keys
-        // The printer will handle this specially
-        self.0.insert("".to_string(), vec![CclObject::empty()]);
+        // Use a sentinel key that cannot collide with real CCL keys. The empty
+        // key `""` is used by bare list items (`= item`), so inserting `""` here
+        // would silently overwrite existing list data (see issue #92). The NUL
+        // sentinel can never appear in parsed CCL, and the printer renders it as
+        // a blank line. Append (rather than insert) so multiple blank lines and
+        // any pre-existing sentinel entries are preserved.
+        self.0
+            .entry(BLANK_LINE_KEY.to_string())
+            .or_default()
+            .push(CclObject::empty());
     }
 
     // ========================================================================
@@ -554,8 +568,12 @@ impl CclObject {
     ///
     /// Returns `Some(items)` if this is a bare list, `None` otherwise.
     pub(crate) fn as_bare_list(&self) -> Option<Vec<String>> {
-        // Filter out comment keys (starting with '/') when checking for bare lists
-        let non_comment_keys: Vec<&String> = self.keys().filter(|k| !k.starts_with('/')).collect();
+        // Filter out comment keys (starting with '/') and blank-line sentinels
+        // when checking for bare lists.
+        let non_comment_keys: Vec<&String> = self
+            .keys()
+            .filter(|k| !k.starts_with('/') && *k != BLANK_LINE_KEY)
+            .collect();
 
         // Handle bare list syntax: single empty-key child containing the list items
         // With Vec structure: { "": [CclObject({item1}), CclObject({item2}), ...] }
@@ -563,7 +581,12 @@ impl CclObject {
             if let Ok(children) = self.get_all("") {
                 let items: Vec<String> = children
                     .iter()
-                    .flat_map(|child| child.keys().filter(|k| !k.starts_with('/')).cloned())
+                    .flat_map(|child| {
+                        child
+                            .keys()
+                            .filter(|k| !k.starts_with('/') && *k != BLANK_LINE_KEY)
+                            .cloned()
+                    })
                     .collect();
                 return Some(items);
             }

--- a/crates/sickle/src/printer.rs
+++ b/crates/sickle/src/printer.rs
@@ -67,7 +67,11 @@ pub fn print(entries: &[Entry]) -> String {
     entries
         .iter()
         .map(|entry| {
-            if entry.key.is_empty() {
+            if entry.key == "/" {
+                // Comment line: the parser represents `/= text` as key `/` with
+                // the text as the value. Round-trip it as `/= text` (issue #205).
+                format!("/= {}", entry.value)
+            } else if entry.key.is_empty() {
                 // Empty keys use bare list syntax: `= value` (no leading space)
                 format!("= {}", entry.value)
             } else {
@@ -196,8 +200,29 @@ impl CclPrinter {
         indent: usize,
         output: &mut String,
     ) {
+        // Handle explicit blank lines: the NUL sentinel key (see issue #92).
+        if key == crate::model::BLANK_LINE_KEY {
+            output.push('\n');
+            return;
+        }
+
         // Handle blank lines: empty key with empty value
         if key.is_empty() && value.is_empty() {
+            output.push('\n');
+            return;
+        }
+
+        // Handle comment lines parsed from CCL: the parser represents `/= text`
+        // as key `/` with the comment text as a string value. Emit it back as
+        // `/= text` (no space after the slash) to round-trip faithfully (issue
+        // #205).
+        if key == "/" {
+            output.push_str(indent_str);
+            output.push_str("/=");
+            if let Some(text) = value.keys().next() {
+                output.push(' ');
+                output.push_str(text);
+            }
             output.push('\n');
             return;
         }

--- a/crates/sickle/tests/document_tests.rs
+++ b/crates/sickle/tests/document_tests.rs
@@ -1,0 +1,239 @@
+//! Integration tests for the comment/format-preserving document API (issue #206).
+//!
+//! These exercise `load_document` / `Document::deserialize` / `Document::reserialize`,
+//! verifying that hand-written comments, blank lines, key order, and formatting
+//! survive a read -> mutate -> write cycle where data is unchanged, and that only
+//! edited regions change.
+
+#![cfg(feature = "document")]
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Source {
+    url: String,
+    branch: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Config {
+    name: String,
+    version: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    nickname: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    sources: BTreeMap<String, Source>,
+}
+
+const SAMPLE: &str = "\
+/= top-level header comment
+name = myapp
+version = 1.0.0
+
+tags =
+  = alpha
+  = beta
+sources =
+  github =
+    url = https://github.com/x
+    branch = main
+";
+
+#[test]
+fn deserialize_matches_from_str() {
+    let doc = sickle::load_document(SAMPLE).unwrap();
+    let cfg: Config = doc.deserialize().unwrap();
+    assert_eq!(cfg.name, "myapp");
+    assert_eq!(cfg.version, "1.0.0");
+    assert_eq!(cfg.tags, vec!["alpha", "beta"]);
+    assert_eq!(cfg.sources["github"].url, "https://github.com/x");
+    assert_eq!(cfg.sources["github"].branch, "main");
+}
+
+#[test]
+fn unchanged_roundtrip_is_byte_identical() {
+    let doc = sickle::load_document(SAMPLE).unwrap();
+    let cfg: Config = doc.deserialize().unwrap();
+    let out = doc.reserialize(&cfg).unwrap();
+    assert_eq!(out, SAMPLE, "unchanged round-trip must be byte-identical");
+}
+
+#[test]
+fn scalar_change_preserves_comments_and_blanks() {
+    let doc = sickle::load_document(SAMPLE).unwrap();
+    let mut cfg: Config = doc.deserialize().unwrap();
+    cfg.version = "2.0.0".to_string();
+    let out = doc.reserialize(&cfg).unwrap();
+
+    assert!(
+        out.contains("/= top-level header comment"),
+        "comment kept: {out}"
+    );
+    assert!(out.contains("version = 2.0.0"), "value updated: {out}");
+    assert!(!out.contains("1.0.0"), "old value gone: {out}");
+    // Blank line between version and tags is preserved.
+    assert!(
+        out.contains("version = 2.0.0\n\ntags ="),
+        "blank kept: {out}"
+    );
+    // Untouched nested block is preserved verbatim.
+    assert!(out.contains("  github =\n    url = https://github.com/x\n    branch = main"));
+}
+
+#[test]
+fn nested_add_preserves_existing_block_and_comments() {
+    let doc = sickle::load_document(SAMPLE).unwrap();
+    let mut cfg: Config = doc.deserialize().unwrap();
+    cfg.sources.insert(
+        "gitlab".to_string(),
+        Source {
+            url: "https://gitlab.com/y".to_string(),
+            branch: "dev".to_string(),
+        },
+    );
+    let out = doc.reserialize(&cfg).unwrap();
+
+    assert!(out.contains("/= top-level header comment"));
+    // existing github block untouched
+    assert!(out.contains("  github =\n    url = https://github.com/x\n    branch = main"));
+    // new gitlab block present and correctly nested
+    assert!(
+        out.contains("  gitlab =\n    url = https://gitlab.com/y\n    branch = dev"),
+        "got: {out}"
+    );
+    // re-reading the result yields the edited config
+    let doc2 = sickle::load_document(&out).unwrap();
+    let cfg2: Config = doc2.deserialize().unwrap();
+    assert_eq!(cfg2, cfg);
+}
+
+#[test]
+fn list_push_appends_and_preserves() {
+    let doc = sickle::load_document(SAMPLE).unwrap();
+    let mut cfg: Config = doc.deserialize().unwrap();
+    cfg.tags.push("gamma".to_string());
+    let out = doc.reserialize(&cfg).unwrap();
+
+    assert!(out.contains("  = alpha\n  = beta\n  = gamma"), "got: {out}");
+    assert!(out.contains("/= top-level header comment"));
+    let cfg2: Config = sickle::load_document(&out).unwrap().deserialize().unwrap();
+    assert_eq!(cfg2.tags, vec!["alpha", "beta", "gamma"]);
+}
+
+#[test]
+fn removing_key_drops_its_attached_comment_but_keeps_header() {
+    let input = "\
+/= file header
+name = myapp
+version = 1.0.0
+/= the nickname for the app
+nickname = buddy
+";
+    let doc = sickle::load_document(input).unwrap();
+    let mut cfg: Config = doc.deserialize().unwrap();
+    assert_eq!(cfg.nickname.as_deref(), Some("buddy"));
+    cfg.nickname = None;
+    let out = doc.reserialize(&cfg).unwrap();
+
+    assert!(out.contains("/= file header"), "header kept: {out}");
+    assert!(!out.contains("nickname"), "removed key gone: {out}");
+    assert!(
+        !out.contains("the nickname for the app"),
+        "attached comment dropped: {out}"
+    );
+}
+
+#[test]
+fn standalone_comment_block_survives_neighbor_removal() {
+    let input = "\
+name = myapp
+version = 1.0.0
+
+/= standalone divider
+
+nickname = buddy
+";
+    let doc = sickle::load_document(input).unwrap();
+    let mut cfg: Config = doc.deserialize().unwrap();
+    cfg.nickname = None;
+    let out = doc.reserialize(&cfg).unwrap();
+    // A comment block separated from the removed key by a blank line is
+    // standalone (not attached) and is kept.
+    assert!(out.contains("standalone divider"), "standalone kept: {out}");
+    assert!(!out.contains("nickname"));
+}
+
+#[test]
+fn nested_comment_survives_sibling_add() {
+    // The headline #206 use case: a comment INSIDE a nested block must survive
+    // when a sibling is added to that block (recursive trivia preservation).
+    let input = "\
+name = myapp
+version = 1.0.0
+tags =
+  = alpha
+  = beta
+sources =
+  /= the canonical upstream remote
+  github =
+    url = https://github.com/x
+    branch = main
+";
+    let doc = sickle::load_document(input).unwrap();
+    let mut cfg: Config = doc.deserialize().unwrap();
+    cfg.sources.insert(
+        "gitlab".to_string(),
+        Source {
+            url: "https://gitlab.com/y".to_string(),
+            branch: "dev".to_string(),
+        },
+    );
+    let out = doc.reserialize(&cfg).unwrap();
+
+    assert!(
+        out.contains("/= the canonical upstream remote"),
+        "nested comment preserved: {out}"
+    );
+    assert!(out.contains("  github =\n    url = https://github.com/x\n    branch = main"));
+    assert!(out.contains("  gitlab =\n    url = https://gitlab.com/y\n    branch = dev"));
+}
+
+#[test]
+fn unchanged_noncanonical_spacing_is_preserved() {
+    // Value unchanged -> keep the user's exact (non-canonical) formatting.
+    let input = "name=app\nversion =   1.0.0\n";
+    let doc = sickle::load_document(input).unwrap();
+    let cfg: Config = doc.deserialize().unwrap();
+    let out = doc.reserialize(&cfg).unwrap();
+    assert_eq!(out, input);
+
+    // Changing a value re-renders just that entry canonically.
+    let mut cfg2 = cfg.clone();
+    cfg2.name = "newapp".to_string();
+    let out2 = doc.reserialize(&cfg2).unwrap();
+    assert!(out2.contains("name = newapp"), "got: {out2}");
+    assert!(
+        out2.contains("version =   1.0.0"),
+        "untouched line kept: {out2}"
+    );
+}
+
+#[test]
+fn no_trailing_newline_is_preserved() {
+    let input = "name = app\nversion = 1.0.0";
+    let doc = sickle::load_document(input).unwrap();
+    let cfg: Config = doc.deserialize().unwrap();
+    let out = doc.reserialize(&cfg).unwrap();
+    assert_eq!(out, input);
+    assert!(!out.ends_with('\n'));
+}
+
+#[test]
+fn display_renders_unmodified_source() {
+    let doc = sickle::load_document(SAMPLE).unwrap();
+    assert_eq!(doc.to_string(), SAMPLE);
+    assert_eq!(doc.render(), SAMPLE);
+}


### PR DESCRIPTION
## Summary

Adds a comment- and format-preserving round-trip document API to `sickle`, analogous to `toml_edit`'s `DocumentMut`. Load a document, deserialize it into a struct, edit, then reserialize — comments, blank lines, and formatting on unchanged regions are preserved byte-for-byte.

Gated behind the new `document` feature (included in `full`).

```rust
let mut doc = sickle::load_document(src)?;
let mut cfg: Config = doc.deserialize()?;
cfg.version = 2;
let out = doc.reserialize(&cfg)?; // comments/blanks preserved
```

## Bug fixes (prerequisites)

- **#205** — top-level comment `/= text` was reformatted to `/ = text` on round-trip.
- **#92** — `add_blank_line()` collided with real map keys.

## Notes

- Unchanged regions render verbatim; only edited entries are recanonicalized.
- CRLF input is normalized to LF (documented in the module).
- A pre-existing, unrelated deserialize limitation surfaced during this work and is tracked separately in #207.

Closes #206, #205, #92

## Testing

`cargo test -p sickle --features full` — 11 new document tests plus the full existing suite pass.
