### PR TITLE
fix(release): bump internal dep requirements and sync Cargo.lock

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -24,6 +24,10 @@ projects:
         - path: crates/santa-data/Cargo.toml
           find: '^version = ".*"$'
           replace: 'version = "{{.Major}}.{{.Minor}}.{{.Patch}}"'
+        # Keep dependents' version requirement in sync with the new release.
+        - path: crates/santa-cli/Cargo.toml
+          find: '^santa-data = \{ version = "[^"]*"'
+          replace: 'santa-data = { version = "{{.Major}}.{{.Minor}}.{{.Patch}}"'
     - label: Sickle
       key: sickle
       changelog: crates/sickle/CHANGELOG.md
@@ -31,6 +35,13 @@ projects:
         - path: crates/sickle/Cargo.toml
           find: '^version = ".*"$'
           replace: 'version = "{{.Major}}.{{.Minor}}.{{.Patch}}"'
+        # Keep dependents' version requirements in sync with the new release.
+        - path: crates/santa-cli/Cargo.toml
+          find: '^sickle = \{ version = "[^"]*"'
+          replace: 'sickle = { version = "{{.Major}}.{{.Minor}}.{{.Patch}}"'
+        - path: crates/santa-data/Cargo.toml
+          find: '^sickle = \{ version = "[^"]*"'
+          replace: 'sickle = { version = "{{.Major}}.{{.Minor}}.{{.Patch}}"'
     - label: Sickle CLI
       key: sickle-cli
       changelog: crates/sickle-cli/CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,14 @@ jobs:
         if: steps.check.outputs.skipped != 'true'
         run: changie merge
 
+      - name: Set up Rust
+        if: steps.check.outputs.skipped != 'true'
+        uses: ./.github/actions/setup-rust
+
+      - name: Sync Cargo.lock with bumped versions
+        if: steps.check.outputs.skipped != 'true'
+        run: cargo update --workspace
+
       - name: Resolve versions
         if: steps.check.outputs.skipped != 'true'
         id: versions


### PR DESCRIPTION
## Summary

Fixes the release tooling so it bumps **all** the right things.

**Root cause:** changie's `replacements` only bumped each crate's own `[package] version`, never the inter-crate dependency *requirements*. When `santa-data` (0.3.x→0.4.0) and `sickle` (0.2.x→0.4.0) were minor-bumped, the stale `santa-data = "0.3.3"` / `sickle = "0.2.0"` lines violated the 0.x `^` ranges and broke the build (`failed to select a version for the requirement`).

A second gap: the release workflow never refreshed `Cargo.lock`, so `--locked` jobs would fail after the manifests were bumped.

## Changes

- **`.changie.yaml`** — added replacements so releasing `santa-data`/`sickle` also rewrites their version requirement in dependent crates' `Cargo.toml`.
- **`.github/workflows/release.yml`** — set up Rust and run `cargo update --workspace` after `changie merge`, syncing `Cargo.lock` before the release PR is opened.

## Verification

Simulated a release end-to-end with changie (`batch` → `merge`): dependency requirements now track the published versions, and `merge` re-applies them idempotently — so even a crate that isn't itself re-released gets a stale `sickle` requirement corrected.

## Note

The in-flight `release/next` PR predates this fix and still needs its manifests + lockfile corrected manually to unblock.
