### PR TITLE
fix(release): conventional release PR title and workspace package verify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
-          title: "Release ${{ steps.versions.outputs.versions }}"
+          title: "build: release ${{ steps.versions.outputs.versions }}"
           branch: release/next
           commit-message: "chore(release): ${{ steps.versions.outputs.versions }}"
           labels: release

--- a/justfile
+++ b/justfile
@@ -319,11 +319,12 @@ release:
     cargo build --release
 
 # Verify packages can be packaged (validates metadata and structure)
-# Uses --no-verify because path deps may not be published to crates.io yet
+# --no-verify because path deps may not be published to crates.io yet.
+# --workspace co-packages the interdependent crates so bumped, not-yet-published
+# versions resolve from the workspace instead of crates.io; sickle-cli is excluded
+# because it is publish = false and depends on sickle without a version.
 verify-package:
-    cargo package --no-verify -p sickle
-    cargo package --no-verify -p santa-data
-    cargo package --no-verify -p santa
+    cargo package --no-verify --workspace --exclude sickle-cli
 
 # Development Workflow Commands
 # ============================


### PR DESCRIPTION
## Summary

Two release-tooling fixes so the regenerated release PR (#214) can go green.

### 1. Conventional release PR title
The auto-generated title `Release …` is rejected by the "Lint PR Title" check
(commitlint requires a Conventional Commit type). Prefix it with `build: `:

`build: release santa-v0.3.4, santa-data-v0.4.0, sickle-v0.4.0`

Verified against `.commitlintrc.json` — passes. The `release` label (used by
auto-tag) is unchanged, so tagging is unaffected.

### 2. Workspace-aware package verification
`just verify-package` packaged each crate individually, which resolves internal
deps from crates.io. A release that bumps an internal dep to a not-yet-published
version (e.g. `sickle 0.4.0`) then fails:

```
failed to select a version for the requirement `sickle = "^0.4.0"`
```

Switched to `cargo package --no-verify --workspace --exclude sickle-cli`, which
co-packages the interdependent crates and resolves sibling versions from the
workspace. `sickle-cli` is excluded (`publish = false`, version-less `sickle`
dep). Verified locally.

## Follow-up

Once merged, the Release workflow re-runs and refreshes #214 with the new title
and the fixed `verify-package`, which should clear its remaining red checks.
