### PR TITLE
feat(sickle): add update_str and edit_str document helpers

### DIFF
--- a/.changes/unreleased/sickle-Added-20260627-091030.yaml
+++ b/.changes/unreleased/sickle-Added-20260627-091030.yaml
@@ -1,0 +1,4 @@
+project: sickle
+kind: Added
+body: Add `update_str` and `edit_str` helpers (document feature) for one-call comment-preserving serde round-trips
+time: 2026-06-27T09:10:30.000000-07:00

--- a/crates/sickle/src/document.rs
+++ b/crates/sickle/src/document.rs
@@ -148,6 +148,65 @@ impl Document {
     }
 }
 
+/// Apply an edited value back onto its original CCL source, preserving comments.
+///
+/// One-call sugar over [`load_document`] + [`Document::reserialize`] for apps
+/// that already hold both the original text and an edited typed value. Comments,
+/// blank lines, key order, and formatting are kept wherever the data is
+/// unchanged; only edited regions are re-rendered.
+///
+/// Requires the `document` feature.
+///
+/// ```
+/// # use serde::{Deserialize, Serialize};
+/// #[derive(Serialize, Deserialize)]
+/// struct Config { name: String, version: String }
+///
+/// let text = "/= my config\nname = app\nversion = 1.0.0\n";
+/// let mut cfg: Config = sickle::from_str(text).unwrap();
+/// cfg.version = "2.0.0".to_string();
+/// let out = sickle::update_str(text, &cfg).unwrap();
+/// assert!(out.contains("/= my config"));    // comment preserved
+/// assert!(out.contains("version = 2.0.0")); // value updated
+/// ```
+pub fn update_str<T: Serialize>(original: &str, value: &T) -> Result<String> {
+    load_document(original)?.reserialize(value)
+}
+
+/// Deserialize `original`, mutate the typed value in `edit`, then reserialize
+/// while preserving comments.
+///
+/// One-call sugar over [`load_document`] + [`Document::deserialize`] +
+/// [`Document::reserialize`] for the common read-modify-write cycle. Comments,
+/// blank lines, key order, and formatting are kept wherever the data is
+/// unchanged; only edited regions are re-rendered.
+///
+/// Requires the `document` feature.
+///
+/// ```
+/// # use serde::{Deserialize, Serialize};
+/// #[derive(Serialize, Deserialize)]
+/// struct Config { name: String, version: String }
+///
+/// let text = "/= my config\nname = app\nversion = 1.0.0\n";
+/// let out = sickle::edit_str(text, |cfg: &mut Config| {
+///     cfg.version = "2.0.0".to_string();
+/// })
+/// .unwrap();
+/// assert!(out.contains("/= my config"));    // comment preserved
+/// assert!(out.contains("version = 2.0.0")); // value updated
+/// ```
+pub fn edit_str<T, F>(original: &str, edit: F) -> Result<String>
+where
+    T: DeserializeOwned + Serialize,
+    F: FnOnce(&mut T),
+{
+    let doc = load_document(original)?;
+    let mut value: T = doc.deserialize()?;
+    edit(&mut value);
+    doc.reserialize(&value)
+}
+
 // ============================================================================
 // Parsing: recursive, line-based, trivia-preserving
 // ============================================================================

--- a/crates/sickle/src/lib.rs
+++ b/crates/sickle/src/lib.rs
@@ -66,7 +66,7 @@
 //! - `serde-deserialize`: Serde deserialization (`from_str`) - includes `hierarchy`
 //! - `serde-serialize`: Serde serialization (`to_string`) - includes `printer`
 //! - `serde`: Both serialization and deserialization
-//! - `document`: Comment/format-preserving edit API ([`load_document`], [`Document`])
+//! - `document`: Comment/format-preserving edit API ([`load_document`], [`Document`], [`update_str`], [`edit_str`])
 //! - `intern`: String interning for memory efficiency with large configs
 //! - `full`: Enable all features
 //!
@@ -97,7 +97,7 @@ pub mod ser;
 pub mod document;
 
 #[cfg(feature = "document")]
-pub use document::{load_document, Document};
+pub use document::{edit_str, load_document, update_str, Document};
 
 pub use error::{Error, Result};
 pub use model::{BoolOptions, CclObject, Entry, ListOptions};

--- a/crates/sickle/tests/document_tests.rs
+++ b/crates/sickle/tests/document_tests.rs
@@ -237,3 +237,75 @@ fn display_renders_unmodified_source() {
     assert_eq!(doc.to_string(), SAMPLE);
     assert_eq!(doc.render(), SAMPLE);
 }
+
+// ---------------------------------------------------------------------------
+// One-call helpers: update_str / edit_str (sugar over Document)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn update_str_preserves_comments_on_edit() {
+    let doc: Config = sickle::from_str(SAMPLE).unwrap();
+    let mut edited = doc;
+    edited.version = "2.0.0".to_string();
+
+    let out = sickle::update_str(SAMPLE, &edited).unwrap();
+    assert!(
+        out.contains("/= top-level header comment"),
+        "comment kept: {out}"
+    );
+    assert!(out.contains("version = 2.0.0"), "value updated: {out}");
+    assert!(out.contains("  github =\n    url = https://github.com/x\n    branch = main"));
+}
+
+#[test]
+fn update_str_unchanged_is_byte_identical() {
+    let cfg: Config = sickle::from_str(SAMPLE).unwrap();
+    let out = sickle::update_str(SAMPLE, &cfg).unwrap();
+    assert_eq!(out, SAMPLE);
+}
+
+#[test]
+fn update_str_matches_document_reserialize() {
+    let mut cfg: Config = sickle::from_str(SAMPLE).unwrap();
+    cfg.tags.push("gamma".to_string());
+
+    let via_helper = sickle::update_str(SAMPLE, &cfg).unwrap();
+    let via_document = sickle::load_document(SAMPLE)
+        .unwrap()
+        .reserialize(&cfg)
+        .unwrap();
+    assert_eq!(via_helper, via_document);
+}
+
+#[test]
+fn edit_str_preserves_comments_on_edit() {
+    let out = sickle::edit_str(SAMPLE, |cfg: &mut Config| {
+        cfg.version = "2.0.0".to_string();
+        cfg.tags.push("gamma".to_string());
+    })
+    .unwrap();
+
+    assert!(
+        out.contains("/= top-level header comment"),
+        "comment kept: {out}"
+    );
+    assert!(out.contains("version = 2.0.0"), "value updated: {out}");
+    assert!(
+        out.contains("  = alpha\n  = beta\n  = gamma"),
+        "list appended: {out}"
+    );
+}
+
+#[test]
+fn edit_str_no_change_is_byte_identical() {
+    let out = sickle::edit_str(SAMPLE, |_cfg: &mut Config| {}).unwrap();
+    assert_eq!(out, SAMPLE);
+}
+
+#[test]
+fn edit_str_propagates_deserialize_error() {
+    // `name` is required; missing it must surface as an error, not a panic.
+    let bad = "version = 1.0.0\n";
+    let result = sickle::edit_str(bad, |_cfg: &mut Config| {});
+    assert!(result.is_err(), "missing required field should error");
+}


### PR DESCRIPTION
## Summary

Adds `update_str` and `edit_str` to sickle (`document` feature) — one-call sugar over `Document` for comment-preserving serde round-trips.

Plain `from_str::<T>` → `to_string` can't retain comments: the typed value has nowhere to hold trivia. These helpers wrap `load_document` + `reserialize` so apps can read-modify-write a config without losing comments, blank lines, key order, or formatting.

```rust
// apply an already-edited value
let out = sickle::update_str(original, &cfg)?;

// deserialize, mutate, reserialize in one call
let out = sickle::edit_str(original, |cfg: &mut Config| {
    cfg.version = "2.0.0".into();
})?;
```

## Changes

- `update_str` / `edit_str` in `document.rs`, re-exported from the crate root
- 6 new tests in `document_tests.rs` (comment preservation, byte-identical no-op, parity with `Document::reserialize`, error propagation)
- Feature-doc update + changelog fragment
